### PR TITLE
Add Steam login button and callback page

### DIFF
--- a/src/pages/callback/steam-callback-page.tsx
+++ b/src/pages/callback/steam-callback-page.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from "react"
+import { baseUrl } from "@/api/api"
+
+export function SteamCallbackPage() {
+  const [error, setError] = useState<string | null>(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (!params.get("openid.claimed_id")) {
+      return "Missing Steam authentication parameters"
+    }
+    return null
+  })
+  const calledRef = useRef(false)
+
+  useEffect(() => {
+    if (error || calledRef.current) return
+    calledRef.current = true
+
+    // Forward Steam's OpenID params to the backend callback
+    fetch(`${baseUrl}/auth/steam/callback${window.location.search}`, {
+      method: "GET",
+      credentials: "include",
+    })
+      .then((res) => {
+        if (res.redirected) {
+          window.location.href = res.url
+          return
+        }
+        if (!res.ok) throw new Error(`Auth failed: ${res.status}`)
+        window.location.href = "/profile"
+      })
+      .catch(() => {
+        setError("Steam sign-in failed. Please try again.")
+      })
+  }, [error])
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-destructive">{error}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <p className="text-muted-foreground">Completing Steam sign in...</p>
+    </div>
+  )
+}

--- a/src/pages/login/login-page.tsx
+++ b/src/pages/login/login-page.tsx
@@ -58,6 +58,21 @@ export function LoginPage() {
     }
   }
 
+  async function handleSteamLogin() {
+    try {
+      const res = await api
+        .get("auth/steam/authorize")
+        .json<{ authorization_url: string }>()
+      window.location.href = res.authorization_url
+    } catch (error) {
+      const message = await getErrorMessage(
+        error,
+        "Failed to start Steam sign-in"
+      )
+      toast.error(message)
+    }
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center px-4">
       <Card className="w-full max-w-sm">
@@ -114,13 +129,22 @@ export function LoginPage() {
             </div>
           </div>
 
-          <Button
-            variant="outline"
-            className="w-full"
-            onClick={handleGoogleLogin}
-          >
-            Sign in with Google
-          </Button>
+          <div className="grid gap-2">
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={handleGoogleLogin}
+            >
+              Sign in with Google
+            </Button>
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={handleSteamLogin}
+            >
+              Sign in with Steam
+            </Button>
+          </div>
         </CardContent>
         <CardFooter className="justify-center">
           <p className="text-muted-foreground text-sm">

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as ProfileRouteImport } from './routes/profile'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as CallbackSteamRouteImport } from './routes/callback/steam'
 import { Route as CallbackGoogleRouteImport } from './routes/callback/google'
 
 const ResetPasswordRoute = ResetPasswordRouteImport.update({
@@ -47,6 +48,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CallbackSteamRoute = CallbackSteamRouteImport.update({
+  id: '/callback/steam',
+  path: '/callback/steam',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CallbackGoogleRoute = CallbackGoogleRouteImport.update({
   id: '/callback/google',
   path: '/callback/google',
@@ -61,6 +67,7 @@ export interface FileRoutesByFullPath {
   '/register': typeof RegisterRoute
   '/reset-password': typeof ResetPasswordRoute
   '/callback/google': typeof CallbackGoogleRoute
+  '/callback/steam': typeof CallbackSteamRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -70,6 +77,7 @@ export interface FileRoutesByTo {
   '/register': typeof RegisterRoute
   '/reset-password': typeof ResetPasswordRoute
   '/callback/google': typeof CallbackGoogleRoute
+  '/callback/steam': typeof CallbackSteamRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -80,6 +88,7 @@ export interface FileRoutesById {
   '/register': typeof RegisterRoute
   '/reset-password': typeof ResetPasswordRoute
   '/callback/google': typeof CallbackGoogleRoute
+  '/callback/steam': typeof CallbackSteamRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -91,6 +100,7 @@ export interface FileRouteTypes {
     | '/register'
     | '/reset-password'
     | '/callback/google'
+    | '/callback/steam'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -100,6 +110,7 @@ export interface FileRouteTypes {
     | '/register'
     | '/reset-password'
     | '/callback/google'
+    | '/callback/steam'
   id:
     | '__root__'
     | '/'
@@ -109,6 +120,7 @@ export interface FileRouteTypes {
     | '/register'
     | '/reset-password'
     | '/callback/google'
+    | '/callback/steam'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -119,6 +131,7 @@ export interface RootRouteChildren {
   RegisterRoute: typeof RegisterRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
   CallbackGoogleRoute: typeof CallbackGoogleRoute
+  CallbackSteamRoute: typeof CallbackSteamRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -165,6 +178,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/callback/steam': {
+      id: '/callback/steam'
+      path: '/callback/steam'
+      fullPath: '/callback/steam'
+      preLoaderRoute: typeof CallbackSteamRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/callback/google': {
       id: '/callback/google'
       path: '/callback/google'
@@ -183,6 +203,7 @@ const rootRouteChildren: RootRouteChildren = {
   RegisterRoute: RegisterRoute,
   ResetPasswordRoute: ResetPasswordRoute,
   CallbackGoogleRoute: CallbackGoogleRoute,
+  CallbackSteamRoute: CallbackSteamRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/callback/steam.tsx
+++ b/src/routes/callback/steam.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { SteamCallbackPage } from "@/pages/callback/steam-callback-page"
+
+export const Route = createFileRoute("/callback/steam")({
+  component: SteamCallbackPage,
+})


### PR DESCRIPTION
## Summary

- "Sign in with Steam" button on login page (alongside Google)
- `/callback/steam` page handles Steam OpenID redirect
- Same pattern as Google OAuth (fetch authorize URL → redirect → callback)

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm run test:run` — 2/2 passing
- [x] `pnpm run lint` — 0 errors
- [ ] CI passes
- [ ] Manual: test Steam login end-to-end