### PR TITLE
Add footer with copyright and platform links

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,0 +1,31 @@
+export function Footer() {
+  const year = new Date().getFullYear()
+
+  return (
+    <footer className="border-border/50 border-t px-4 py-3">
+      <div className="text-muted-foreground flex items-center justify-between text-xs">
+        <p>&copy; {year} CriticalBit. All rights reserved.</p>
+        <div className="flex gap-4">
+          <a
+            href="https://criticalbit.gg"
+            className="hover:text-foreground transition-colors"
+          >
+            criticalbit.gg
+          </a>
+          <a
+            href="https://criticalbit.gg/privacy"
+            className="hover:text-foreground transition-colors"
+          >
+            Privacy
+          </a>
+          <a
+            href="https://criticalbit.gg/terms"
+            className="hover:text-foreground transition-colors"
+          >
+            Terms
+          </a>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/src/pages/callback/google-callback-page.tsx
+++ b/src/pages/callback/google-callback-page.tsx
@@ -30,14 +30,14 @@ export function GoogleCallbackPage() {
 
   if (error) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex flex-1 items-center justify-center">
         <p className="text-destructive">{error}</p>
       </div>
     )
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center">
+    <div className="flex flex-1 items-center justify-center">
       <p className="text-muted-foreground">Completing sign in...</p>
     </div>
   )

--- a/src/pages/callback/steam-callback-page.tsx
+++ b/src/pages/callback/steam-callback-page.tsx
@@ -35,14 +35,14 @@ export function SteamCallbackPage() {
 
   if (error) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex flex-1 items-center justify-center">
         <p className="text-destructive">{error}</p>
       </div>
     )
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center">
+    <div className="flex flex-1 items-center justify-center">
       <p className="text-muted-foreground">Completing Steam sign in...</p>
     </div>
   )

--- a/src/pages/forgot-password/forgot-password-page.tsx
+++ b/src/pages/forgot-password/forgot-password-page.tsx
@@ -39,7 +39,7 @@ export function ForgotPasswordPage() {
 
   if (submitted) {
     return (
-      <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="flex flex-1 items-center justify-center px-4">
         <Card className="w-full max-w-sm">
           <CardHeader className="text-center">
             <CardTitle className="text-2xl">Check your email</CardTitle>
@@ -58,7 +58,7 @@ export function ForgotPasswordPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-4">
+    <div className="flex flex-1 items-center justify-center px-4">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <CardTitle className="text-2xl">Forgot password</CardTitle>

--- a/src/pages/login/login-page.tsx
+++ b/src/pages/login/login-page.tsx
@@ -65,7 +65,7 @@ export function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-4">
+    <div className="flex flex-1 items-center justify-center px-4">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <CardTitle className="font-pixel text-3xl tracking-wide">

--- a/src/pages/profile/profile-page.tsx
+++ b/src/pages/profile/profile-page.tsx
@@ -11,7 +11,7 @@ export function ProfilePage() {
   const auth = useAuth()
 
   return (
-    <div className="flex min-h-[calc(100vh-3.5rem)] items-center justify-center px-4">
+    <div className="flex flex-1 items-center justify-center px-4">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <div className="bg-primary text-primary-foreground mx-auto mb-2 flex size-16 items-center justify-center rounded-full text-2xl font-medium">

--- a/src/pages/register/register-page.tsx
+++ b/src/pages/register/register-page.tsx
@@ -52,7 +52,7 @@ export function RegisterPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-4">
+    <div className="flex flex-1 items-center justify-center px-4">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <CardTitle className="text-2xl">Create account</CardTitle>

--- a/src/pages/reset-password/reset-password-page.tsx
+++ b/src/pages/reset-password/reset-password-page.tsx
@@ -26,7 +26,7 @@ export function ResetPasswordPage() {
 
   if (!token) {
     return (
-      <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="flex flex-1 items-center justify-center px-4">
         <Card className="w-full max-w-sm">
           <CardHeader className="text-center">
             <CardTitle className="text-2xl">Invalid link</CardTitle>
@@ -77,7 +77,7 @@ export function ResetPasswordPage() {
 
   if (success) {
     return (
-      <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="flex flex-1 items-center justify-center px-4">
         <Card className="w-full max-w-sm">
           <CardHeader className="text-center">
             <CardTitle className="text-2xl">Password reset</CardTitle>
@@ -96,7 +96,7 @@ export function ResetPasswordPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-4">
+    <div className="flex flex-1 items-center justify-center px-4">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <CardTitle className="text-2xl">Reset password</CardTitle>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-router"
 import { Toaster } from "sonner"
 import { RootErrorComponent } from "@/components/error-boundary"
+import { Footer } from "@/components/footer"
 import { Navbar } from "@/components/navbar"
 import { NotFound } from "@/components/not-found"
 import { useAnalytics } from "@/lib/analytics"
@@ -62,8 +63,11 @@ function RootComponent() {
     <>
       <RouteTracker />
       <Navbar />
-      <div className="pt-14">
-        <Outlet />
+      <div className="flex min-h-screen flex-col pt-14">
+        <div className="flex flex-1 flex-col">
+          <Outlet />
+        </div>
+        <Footer />
       </div>
       <Toaster position="bottom-right" richColors closeButton />
       <Suspense fallback={null}>


### PR DESCRIPTION
## Summary

- Compact footer: copyright on left, links (criticalbit.gg, Privacy, Terms) on right
- Footer stays at bottom via flex layout in root component
- Update all page containers for proper vertical centering
- Privacy and Terms links point to hub site (dead links until hub is built)

Closes #8

## Test plan

- [x] Build, test, lint clean
- [x] Visual: card centered, footer at bottom on all pages