### PR TITLE
Add account deletion to profile page

### DIFF
--- a/src/pages/forgot-password/forgot-password-page.tsx
+++ b/src/pages/forgot-password/forgot-password-page.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react"
 import { Link } from "@tanstack/react-router"
+import { LoaderCircle } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import {
@@ -81,7 +82,8 @@ export function ForgotPasswordPage() {
               />
             </div>
             <Button type="submit" className="w-full" disabled={isSubmitting}>
-              {isSubmitting ? "Sending..." : "Send reset link"}
+              Send reset link
+              {isSubmitting && <LoaderCircle className="animate-spin" />}
             </Button>
           </form>
         </CardContent>

--- a/src/pages/login/login-page.tsx
+++ b/src/pages/login/login-page.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react"
 import { Link, useSearch } from "@tanstack/react-router"
+import { LoaderCircle } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import {
@@ -109,7 +110,8 @@ export function LoginPage() {
               />
             </div>
             <Button type="submit" className="w-full" disabled={isSubmitting}>
-              {isSubmitting ? "Signing in..." : "Sign in"}
+              Sign in
+              {isSubmitting && <LoaderCircle className="animate-spin" />}
             </Button>
           </form>
 

--- a/src/pages/profile/profile-page.tsx
+++ b/src/pages/profile/profile-page.tsx
@@ -1,8 +1,30 @@
+import { useState } from "react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { api } from "@/api/api"
+import { getErrorMessage } from "@/lib/api-errors"
 import { useAuth } from "@/lib/auth"
 
 export function ProfilePage() {
   const auth = useAuth()
+  const [showConfirm, setShowConfirm] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  async function handleDelete() {
+    setIsDeleting(true)
+    try {
+      await api.delete("auth/me")
+      toast.success("Account deleted.")
+      window.location.href = "/login"
+    } catch (error) {
+      const message = await getErrorMessage(error, "Failed to delete account")
+      toast.error(message)
+    } finally {
+      setIsDeleting(false)
+      setShowConfirm(false)
+    }
+  }
 
   return (
     <div className="flex flex-1 items-center justify-center px-4">
@@ -15,10 +37,48 @@ export function ProfilePage() {
             Profile
           </CardTitle>
         </CardHeader>
-        <CardContent className="grid gap-3">
+        <CardContent className="grid gap-4">
           <div className="grid gap-1 text-sm">
             <span className="text-muted-foreground">Email</span>
             <span>{auth.email}</span>
+          </div>
+
+          <div className="border-border/50 border-t pt-4">
+            {showConfirm ? (
+              <div className="grid gap-2">
+                <p className="text-destructive-foreground text-sm">
+                  Are you sure? This permanently deletes your account and all
+                  data. This cannot be undone.
+                </p>
+                <div className="grid grid-cols-2 gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setShowConfirm(false)}
+                    disabled={isDeleting}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={handleDelete}
+                    disabled={isDeleting}
+                  >
+                    {isDeleting ? "Deleting..." : "Delete"}
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-muted-foreground hover:text-destructive-foreground w-full"
+                onClick={() => setShowConfirm(true)}
+              >
+                Delete account
+              </Button>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/src/pages/profile/profile-page.tsx
+++ b/src/pages/profile/profile-page.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react"
+import { LoaderCircle } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 import { api } from "@/api/api"
 import { getErrorMessage } from "@/lib/api-errors"
 import { useAuth } from "@/lib/auth"
@@ -9,9 +12,13 @@ import { useAuth } from "@/lib/auth"
 export function ProfilePage() {
   const auth = useAuth()
   const [showConfirm, setShowConfirm] = useState(false)
+  const [confirmEmail, setConfirmEmail] = useState("")
   const [isDeleting, setIsDeleting] = useState(false)
 
-  async function handleDelete() {
+  async function handleDelete(e: React.FormEvent) {
+    e.preventDefault()
+    if (confirmEmail !== auth.email) return
+
     setIsDeleting(true)
     try {
       await api.delete("auth/me")
@@ -22,7 +29,6 @@ export function ProfilePage() {
       toast.error(message)
     } finally {
       setIsDeleting(false)
-      setShowConfirm(false)
     }
   }
 
@@ -43,41 +49,67 @@ export function ProfilePage() {
             <span>{auth.email}</span>
           </div>
 
-          <div className="border-border/50 border-t pt-4">
+          <div className="border-destructive/30 bg-destructive/5 rounded-md border p-4">
+            <h3 className="text-destructive-foreground mb-1 text-sm font-semibold">
+              Danger zone
+            </h3>
             {showConfirm ? (
-              <div className="grid gap-2">
-                <p className="text-destructive-foreground text-sm">
-                  Are you sure? This permanently deletes your account and all
-                  data. This cannot be undone.
+              <form onSubmit={handleDelete} className="mt-3 grid gap-3">
+                <p className="text-muted-foreground text-xs">
+                  This permanently deletes your account and all data. This
+                  cannot be undone. Type your email to confirm.
                 </p>
+                <div className="grid gap-1">
+                  <Label htmlFor="confirm-email" className="text-xs">
+                    Type <strong>{auth.email}</strong> to confirm
+                  </Label>
+                  <Input
+                    id="confirm-email"
+                    type="email"
+                    value={confirmEmail}
+                    onChange={(e) => setConfirmEmail(e.target.value)}
+                    placeholder={auth.email ?? ""}
+                    autoComplete="off"
+                  />
+                </div>
                 <div className="grid grid-cols-2 gap-2">
                   <Button
+                    type="button"
                     variant="outline"
                     size="sm"
-                    onClick={() => setShowConfirm(false)}
+                    onClick={() => {
+                      setShowConfirm(false)
+                      setConfirmEmail("")
+                    }}
                     disabled={isDeleting}
                   >
                     Cancel
                   </Button>
                   <Button
+                    type="submit"
                     variant="destructive"
                     size="sm"
-                    onClick={handleDelete}
-                    disabled={isDeleting}
+                    disabled={isDeleting || confirmEmail !== auth.email}
                   >
-                    {isDeleting ? "Deleting..." : "Delete"}
+                    Delete account
+                    {isDeleting && <LoaderCircle className="animate-spin" />}
                   </Button>
                 </div>
-              </div>
+              </form>
             ) : (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="text-muted-foreground hover:text-destructive-foreground w-full"
-                onClick={() => setShowConfirm(true)}
-              >
-                Delete account
-              </Button>
+              <>
+                <p className="text-muted-foreground mb-3 text-xs">
+                  Permanently delete your account and all associated data.
+                </p>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  className="w-full"
+                  onClick={() => setShowConfirm(true)}
+                >
+                  Delete account
+                </Button>
+              </>
             )}
           </div>
         </CardContent>

--- a/src/pages/register/register-page.tsx
+++ b/src/pages/register/register-page.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react"
 import { Link, useNavigate } from "@tanstack/react-router"
+import { LoaderCircle } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import {
@@ -97,7 +98,8 @@ export function RegisterPage() {
               />
             </div>
             <Button type="submit" className="w-full" disabled={isSubmitting}>
-              {isSubmitting ? "Creating account..." : "Create account"}
+              Create account
+              {isSubmitting && <LoaderCircle className="animate-spin" />}
             </Button>
           </form>
         </CardContent>

--- a/src/pages/reset-password/reset-password-page.tsx
+++ b/src/pages/reset-password/reset-password-page.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react"
 import { Link, useSearch } from "@tanstack/react-router"
+import { LoaderCircle } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import {
@@ -129,7 +130,8 @@ export function ResetPasswordPage() {
               />
             </div>
             <Button type="submit" className="w-full" disabled={isSubmitting}>
-              {isSubmitting ? "Resetting..." : "Reset password"}
+              Reset password
+              {isSubmitting && <LoaderCircle className="animate-spin" />}
             </Button>
           </form>
         </CardContent>


### PR DESCRIPTION
## Summary

Two-step account deletion on the profile page:
1. "Delete account" ghost button at the bottom
2. Reveals confirmation warning + Cancel/Delete buttons
3. Calls `DELETE /auth/me`, redirects to login on success

Requires backend PR ag-tech-group/criticalbit-auth-api#12.