### PR TITLE
Show user avatars from OAuth providers

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,6 +1,7 @@
 import { LogOut } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ThemeToggle } from "@/components/theme-toggle"
+import { UserAvatar } from "@/components/user-avatar"
 import { useAuth } from "@/lib/auth"
 
 export function Navbar() {
@@ -21,11 +22,9 @@ export function Navbar() {
           {auth.isAuthenticated && (
             <>
               <div className="flex items-center gap-2">
-                <div className="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full text-xs font-medium">
-                  {auth.email?.charAt(0).toUpperCase() ?? "?"}
-                </div>
+                <UserAvatar size="sm" />
                 <span className="text-muted-foreground hidden text-sm sm:inline">
-                  {auth.email}
+                  {auth.displayName ?? auth.email}
                 </span>
               </div>
               <Button

--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -1,0 +1,24 @@
+import { useAuth } from "@/lib/auth"
+
+export function UserAvatar({ size = "sm" }: { size?: "sm" | "lg" }) {
+  const auth = useAuth()
+  const sizeClass = size === "lg" ? "size-16 text-2xl" : "size-7 text-xs"
+
+  if (auth.avatarUrl) {
+    return (
+      <img
+        src={auth.avatarUrl}
+        alt=""
+        className={`${sizeClass} rounded-full object-cover`}
+      />
+    )
+  }
+
+  return (
+    <div
+      className={`bg-primary text-primary-foreground flex items-center justify-center rounded-full font-medium ${sizeClass}`}
+    >
+      {auth.email?.charAt(0).toUpperCase() ?? "?"}
+    </div>
+  )
+}

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -16,6 +16,8 @@ interface AuthContextValue {
   isLoading: boolean
   email: string | null
   userId: string | null
+  displayName: string | null
+  avatarUrl: string | null
   login: (email: string) => void
   logout: () => Promise<void>
   checkAuth: () => Promise<void>
@@ -31,12 +33,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     localStorage.getItem(EMAIL_KEY)
   )
   const [userId, setUserId] = useState<string | null>(null)
+  const [displayName, setDisplayName] = useState<string | null>(null)
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null)
 
   const clearState = useCallback(() => {
     localStorage.removeItem(EMAIL_KEY)
     setIsAuthenticated(false)
     setEmail(null)
     setUserId(null)
+    setDisplayName(null)
+    setAvatarUrl(null)
     queryClient.clear()
   }, [queryClient])
 
@@ -57,12 +63,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const checkAuth = useCallback(async () => {
     try {
-      const user = await api
-        .get("auth/me")
-        .json<{ id: string; email: string }>()
+      const user = await api.get("auth/me").json<{
+        id: string
+        email: string
+        display_name: string | null
+        avatar_url: string | null
+      }>()
       setIsAuthenticated(true)
       setEmail(user.email)
       setUserId(user.id)
+      setDisplayName(user.display_name)
+      setAvatarUrl(user.avatar_url)
       localStorage.setItem(EMAIL_KEY, user.email)
     } catch {
       clearState()
@@ -87,11 +98,23 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       isLoading,
       email,
       userId,
+      displayName,
+      avatarUrl,
       login,
       logout,
       checkAuth,
     }),
-    [isAuthenticated, isLoading, email, userId, login, logout, checkAuth]
+    [
+      isAuthenticated,
+      isLoading,
+      email,
+      userId,
+      displayName,
+      avatarUrl,
+      login,
+      logout,
+      checkAuth,
+    ]
   )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/src/pages/login/login-page.test.tsx
+++ b/src/pages/login/login-page.test.tsx
@@ -8,6 +8,8 @@ const unauthContext = {
     isLoading: false,
     email: null,
     userId: null,
+    displayName: null,
+    avatarUrl: null,
     login: () => {},
     logout: async () => {},
     checkAuth: async () => {},

--- a/src/pages/profile/profile-page.tsx
+++ b/src/pages/profile/profile-page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { UserAvatar } from "@/components/user-avatar"
 import { api } from "@/api/api"
 import { getErrorMessage } from "@/lib/api-errors"
 import { useAuth } from "@/lib/auth"
@@ -36,8 +37,8 @@ export function ProfilePage() {
     <div className="flex flex-1 items-center justify-center px-4">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
-          <div className="bg-primary text-primary-foreground mx-auto mb-2 flex size-16 items-center justify-center rounded-full text-2xl font-medium">
-            {auth.email?.charAt(0).toUpperCase() ?? "?"}
+          <div className="mx-auto mb-2">
+            <UserAvatar size="lg" />
           </div>
           <CardTitle className="font-pixel text-2xl tracking-wide">
             Profile

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -35,6 +35,8 @@ interface RouterContext {
     isLoading: boolean
     email: string | null
     userId: string | null
+    displayName: string | null
+    avatarUrl: string | null
     login: (email: string) => void
     logout: () => Promise<void>
     checkAuth: () => Promise<void>

--- a/src/test/renderers.tsx
+++ b/src/test/renderers.tsx
@@ -21,6 +21,8 @@ interface RenderWithFileRoutesOptions extends Omit<RenderOptions, "wrapper"> {
       isLoading: boolean
       email: string | null
       userId: string | null
+      displayName: string | null
+      avatarUrl: string | null
       login: (email: string) => void
       logout: () => Promise<void>
       checkAuth: () => Promise<void>
@@ -33,6 +35,8 @@ const defaultAuth = {
   isLoading: false,
   email: "test@example.com",
   userId: "test-user-id",
+  displayName: null,
+  avatarUrl: null,
   login: () => {},
   logout: async () => {},
   checkAuth: async () => {},


### PR DESCRIPTION
## Summary

- Add `displayName` and `avatarUrl` to auth context (from `GET /auth/me`)
- `UserAvatar` component: shows OAuth avatar image or email initial fallback
- Navbar shows avatar + display name (falls back to email)
- Profile page uses `UserAvatar`
- Update test fixtures

Requires backend PR ag-tech-group/criticalbit-auth-api#13.