### PR TITLE
ToS checkbox on registration with auto-login

### DIFF
--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import { CheckIcon } from "lucide-react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -18,6 +18,7 @@ interface AuthContextValue {
   userId: string | null
   displayName: string | null
   avatarUrl: string | null
+  tosAcceptedAt: string | null
   login: (email: string) => void
   logout: () => Promise<void>
   checkAuth: () => Promise<void>
@@ -35,6 +36,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [userId, setUserId] = useState<string | null>(null)
   const [displayName, setDisplayName] = useState<string | null>(null)
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null)
+  const [tosAcceptedAt, setTosAcceptedAt] = useState<string | null>(null)
 
   const clearState = useCallback(() => {
     localStorage.removeItem(EMAIL_KEY)
@@ -42,6 +44,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setEmail(null)
     setUserId(null)
     setDisplayName(null)
+    setTosAcceptedAt(null)
     setAvatarUrl(null)
     queryClient.clear()
   }, [queryClient])
@@ -68,12 +71,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         email: string
         display_name: string | null
         avatar_url: string | null
+        tos_accepted_at: string | null
       }>()
       setIsAuthenticated(true)
       setEmail(user.email)
       setUserId(user.id)
       setDisplayName(user.display_name)
       setAvatarUrl(user.avatar_url)
+      setTosAcceptedAt(user.tos_accepted_at)
       localStorage.setItem(EMAIL_KEY, user.email)
     } catch {
       clearState()
@@ -100,6 +105,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       userId,
       displayName,
       avatarUrl,
+      tosAcceptedAt,
       login,
       logout,
       checkAuth,
@@ -111,6 +117,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       userId,
       displayName,
       avatarUrl,
+      tosAcceptedAt,
       login,
       logout,
       checkAuth,

--- a/src/pages/accept-terms/accept-terms-page.tsx
+++ b/src/pages/accept-terms/accept-terms-page.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react"
+import { LoaderCircle } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
+import { api } from "@/api/api"
+import { getErrorMessage } from "@/lib/api-errors"
+
+export function AcceptTermsPage() {
+  const [accepted, setAccepted] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  async function handleAccept(e: React.FormEvent) {
+    e.preventDefault()
+    if (!accepted) return
+
+    setIsSubmitting(true)
+    try {
+      await api.post("auth/accept-tos")
+      const savedRedirect = localStorage.getItem("auth_redirect")
+      localStorage.removeItem("auth_redirect")
+      window.location.href = savedRedirect ?? "/profile"
+    } catch (error) {
+      const message = await getErrorMessage(error, "Failed to accept terms")
+      toast.error(message)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-1 items-center justify-center px-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <CardTitle className="font-pixel text-2xl tracking-wide">
+            Terms of Service
+          </CardTitle>
+          <CardDescription>
+            Please accept our terms to continue using criticalbit.gg
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleAccept} className="grid gap-4">
+            <label className="flex cursor-pointer items-start gap-3">
+              <Checkbox
+                checked={accepted}
+                onCheckedChange={(checked) => setAccepted(checked === true)}
+                disabled={isSubmitting}
+                className="mt-0.5 shrink-0"
+              />
+              <span className="text-muted-foreground text-xs leading-relaxed">
+                I agree to the{" "}
+                <a
+                  href="https://criticalbit.gg/terms"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline"
+                >
+                  Terms of Service
+                </a>{" "}
+                and{" "}
+                <a
+                  href="https://criticalbit.gg/privacy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline"
+                >
+                  Privacy Policy
+                </a>
+              </span>
+            </label>
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={isSubmitting || !accepted}
+            >
+              Continue
+              {isSubmitting && <LoaderCircle className="animate-spin" />}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/pages/callback/oauth-complete-page.tsx
+++ b/src/pages/callback/oauth-complete-page.tsx
@@ -1,10 +1,30 @@
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
+import { api } from "@/api/api"
 
 export function OAuthCompletePage() {
+  const calledRef = useRef(false)
+
   useEffect(() => {
-    const savedRedirect = localStorage.getItem("auth_redirect")
-    localStorage.removeItem("auth_redirect")
-    window.location.href = savedRedirect ?? "/profile"
+    if (calledRef.current) return
+    calledRef.current = true
+
+    // Check if user has accepted ToS
+    api
+      .get("auth/me")
+      .json<{ tos_accepted_at: string | null }>()
+      .then((user) => {
+        if (!user.tos_accepted_at) {
+          // Keep the redirect in localStorage — accept-terms page will use it
+          window.location.href = "/accept-terms"
+        } else {
+          const savedRedirect = localStorage.getItem("auth_redirect")
+          localStorage.removeItem("auth_redirect")
+          window.location.href = savedRedirect ?? "/profile"
+        }
+      })
+      .catch(() => {
+        window.location.href = "/login"
+      })
   }, [])
 
   return (

--- a/src/pages/login/login-page.test.tsx
+++ b/src/pages/login/login-page.test.tsx
@@ -10,6 +10,7 @@ const unauthContext = {
     userId: null,
     displayName: null,
     avatarUrl: null,
+    tosAcceptedAt: null,
     login: () => {},
     logout: async () => {},
     checkAuth: async () => {},

--- a/src/pages/register/register-page.tsx
+++ b/src/pages/register/register-page.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react"
-import { Link, useNavigate } from "@tanstack/react-router"
+import { Link } from "@tanstack/react-router"
 import { LoaderCircle } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   Card,
   CardContent,
@@ -17,10 +18,10 @@ import { api } from "@/api/api"
 import { getErrorMessage } from "@/lib/api-errors"
 
 export function RegisterPage() {
-  const navigate = useNavigate()
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
+  const [tosAccepted, setTosAccepted] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   async function handleSubmit(e: React.FormEvent) {
@@ -42,8 +43,14 @@ export function RegisterPage() {
       await api.post("auth/register", {
         json: { email, password },
       })
-      toast.success("Account created! Please sign in.")
-      navigate({ to: "/login" })
+      // Auto-login after registration
+      await api.post("auth/jwt/login", {
+        body: new URLSearchParams({ username: email, password }),
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      })
+      // Record ToS acceptance while authenticated
+      await api.post("auth/accept-tos")
+      window.location.href = "/profile"
     } catch (error) {
       const message = await getErrorMessage(error, "Registration failed")
       toast.error(message)
@@ -97,7 +104,39 @@ export function RegisterPage() {
                 autoComplete="new-password"
               />
             </div>
-            <Button type="submit" className="w-full" disabled={isSubmitting}>
+            <label className="flex cursor-pointer items-start gap-3">
+              <Checkbox
+                checked={tosAccepted}
+                onCheckedChange={(checked) => setTosAccepted(checked === true)}
+                disabled={isSubmitting}
+                className="mt-0.5 shrink-0"
+              />
+              <span className="text-muted-foreground text-xs leading-relaxed">
+                I agree to the{" "}
+                <a
+                  href="https://criticalbit.gg/terms"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline"
+                >
+                  Terms of Service
+                </a>{" "}
+                and{" "}
+                <a
+                  href="https://criticalbit.gg/privacy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline"
+                >
+                  Privacy Policy
+                </a>
+              </span>
+            </label>
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={isSubmitting || !tosAccepted}
+            >
               Create account
               {isSubmitting && <LoaderCircle className="animate-spin" />}
             </Button>

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as RegisterRouteImport } from './routes/register'
 import { Route as ProfileRouteImport } from './routes/profile'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
+import { Route as AcceptTermsRouteImport } from './routes/accept-terms'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as CallbackSteamCompleteRouteImport } from './routes/callback/steam-complete'
 import { Route as CallbackSteamRouteImport } from './routes/callback/steam'
@@ -45,6 +46,11 @@ const ForgotPasswordRoute = ForgotPasswordRouteImport.update({
   path: '/forgot-password',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AcceptTermsRoute = AcceptTermsRouteImport.update({
+  id: '/accept-terms',
+  path: '/accept-terms',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -73,6 +79,7 @@ const CallbackGoogleRoute = CallbackGoogleRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/accept-terms': typeof AcceptTermsRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
   '/profile': typeof ProfileRoute
@@ -85,6 +92,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/accept-terms': typeof AcceptTermsRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
   '/profile': typeof ProfileRoute
@@ -98,6 +106,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/accept-terms': typeof AcceptTermsRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
   '/profile': typeof ProfileRoute
@@ -112,6 +121,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/accept-terms'
     | '/forgot-password'
     | '/login'
     | '/profile'
@@ -124,6 +134,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/accept-terms'
     | '/forgot-password'
     | '/login'
     | '/profile'
@@ -136,6 +147,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/accept-terms'
     | '/forgot-password'
     | '/login'
     | '/profile'
@@ -149,6 +161,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AcceptTermsRoute: typeof AcceptTermsRoute
   ForgotPasswordRoute: typeof ForgotPasswordRoute
   LoginRoute: typeof LoginRoute
   ProfileRoute: typeof ProfileRoute
@@ -197,6 +210,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ForgotPasswordRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/accept-terms': {
+      id: '/accept-terms'
+      path: '/accept-terms'
+      fullPath: '/accept-terms'
+      preLoaderRoute: typeof AcceptTermsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -237,6 +257,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AcceptTermsRoute: AcceptTermsRoute,
   ForgotPasswordRoute: ForgotPasswordRoute,
   LoginRoute: LoginRoute,
   ProfileRoute: ProfileRoute,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -37,6 +37,7 @@ interface RouterContext {
     userId: string | null
     displayName: string | null
     avatarUrl: string | null
+    tosAcceptedAt: string | null
     login: (email: string) => void
     logout: () => Promise<void>
     checkAuth: () => Promise<void>

--- a/src/routes/accept-terms.tsx
+++ b/src/routes/accept-terms.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, redirect } from "@tanstack/react-router"
+import { AcceptTermsPage } from "@/pages/accept-terms/accept-terms-page"
+
+export const Route = createFileRoute("/accept-terms")({
+  beforeLoad: ({ context }) => {
+    if (!context.auth.isAuthenticated) {
+      throw redirect({ to: "/login" })
+    }
+  },
+  component: AcceptTermsPage,
+})

--- a/src/test/renderers.tsx
+++ b/src/test/renderers.tsx
@@ -23,6 +23,7 @@ interface RenderWithFileRoutesOptions extends Omit<RenderOptions, "wrapper"> {
       userId: string | null
       displayName: string | null
       avatarUrl: string | null
+      tosAcceptedAt: string | null
       login: (email: string) => void
       logout: () => Promise<void>
       checkAuth: () => Promise<void>
@@ -37,6 +38,7 @@ const defaultAuth = {
   userId: "test-user-id",
   displayName: null,
   avatarUrl: null,
+  tosAcceptedAt: null,
   login: () => {},
   logout: async () => {},
   checkAuth: async () => {},


### PR DESCRIPTION
## Summary

- Required ToS/privacy checkbox on registration form (disabled submit until checked)
- Auto-login after registration
- Calls `POST /auth/accept-tos` to record acceptance with timestamp and version
- Redirects to profile after successful registration

Requires backend PR ag-tech-group/criticalbit-auth-api#14.