### PR TITLE
feat: granular consent on signup, settings, and re-prompt

### DIFF
--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react"
 import { api, setOnUnauthorized } from "@/api/api"
+import { fetchConsents, type ConsentsResponse } from "@/lib/consent"
 
 const EMAIL_KEY = "app_auth_email"
 
@@ -19,9 +20,11 @@ interface AuthContextValue {
   displayName: string | null
   avatarUrl: string | null
   tosAcceptedAt: string | null
+  consents: ConsentsResponse | null
   login: (email: string) => void
   logout: () => Promise<void>
   checkAuth: () => Promise<void>
+  setConsents: (consents: ConsentsResponse) => void
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
@@ -37,6 +40,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [displayName, setDisplayName] = useState<string | null>(null)
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null)
   const [tosAcceptedAt, setTosAcceptedAt] = useState<string | null>(null)
+  const [consents, setConsents] = useState<ConsentsResponse | null>(null)
 
   const clearState = useCallback(() => {
     localStorage.removeItem(EMAIL_KEY)
@@ -46,6 +50,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setDisplayName(null)
     setTosAcceptedAt(null)
     setAvatarUrl(null)
+    setConsents(null)
     queryClient.clear()
   }, [queryClient])
 
@@ -80,6 +85,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setAvatarUrl(user.avatar_url)
       setTosAcceptedAt(user.tos_accepted_at)
       localStorage.setItem(EMAIL_KEY, user.email)
+      // Consent hydration must not block auth — if the fetch fails the user
+      // still appears logged in; the root guard treats null consents as
+      // "nothing stale" so the app stays usable.
+      try {
+        setConsents(await fetchConsents())
+      } catch {
+        setConsents(null)
+      }
     } catch {
       clearState()
     } finally {
@@ -106,9 +119,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       displayName,
       avatarUrl,
       tosAcceptedAt,
+      consents,
       login,
       logout,
       checkAuth,
+      setConsents,
     }),
     [
       isAuthenticated,
@@ -118,6 +133,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       displayName,
       avatarUrl,
       tosAcceptedAt,
+      consents,
       login,
       logout,
       checkAuth,

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -1,0 +1,38 @@
+import { api } from "@/api/api"
+
+export const CONSENT_TYPES = ["analytics", "session_replay"] as const
+export type ConsentType = (typeof CONSENT_TYPES)[number]
+
+export interface ConsentEntry {
+  consented: boolean
+  version: string
+  consented_at: string
+  is_stale: boolean
+}
+
+export interface ConsentsResponse {
+  current_policy_version: string
+  consents: Partial<Record<ConsentType, ConsentEntry>>
+}
+
+export interface ConsentInput {
+  type: ConsentType
+  consented: boolean
+}
+
+export async function fetchConsents(): Promise<ConsentsResponse> {
+  return api.get("user/consents").json<ConsentsResponse>()
+}
+
+export async function submitConsents(
+  consents: ConsentInput[]
+): Promise<ConsentsResponse> {
+  return api
+    .post("user/consents", { json: { consents } })
+    .json<ConsentsResponse>()
+}
+
+export function hasStaleConsent(consents: ConsentsResponse | null): boolean {
+  if (!consents) return false
+  return Object.values(consents.consents).some((entry) => entry?.is_stale)
+}

--- a/src/pages/login/login-page.test.tsx
+++ b/src/pages/login/login-page.test.tsx
@@ -11,9 +11,11 @@ const unauthContext = {
     displayName: null,
     avatarUrl: null,
     tosAcceptedAt: null,
+    consents: null,
     login: () => {},
     logout: async () => {},
     checkAuth: async () => {},
+    setConsents: () => {},
   },
 }
 

--- a/src/pages/profile/profile-page.tsx
+++ b/src/pages/profile/profile-page.tsx
@@ -1,20 +1,62 @@
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { LoaderCircle } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { UserAvatar } from "@/components/user-avatar"
 import { api } from "@/api/api"
 import { getErrorMessage } from "@/lib/api-errors"
 import { useAuth } from "@/lib/auth"
+import {
+  hasStaleConsent,
+  submitConsents,
+  type ConsentInput,
+  type ConsentType,
+} from "@/lib/consent"
+import { Route as ProfileRoute } from "@/routes/profile"
+
+interface ConsentToggleCopy {
+  label: string
+  helper: string
+}
+
+const CONSENT_COPY: Record<ConsentType, ConsentToggleCopy> = {
+  analytics: {
+    label: "Analytics",
+    helper:
+      "Help us understand how the site is used across sessions. Enables analytics cookies.",
+  },
+  session_replay: {
+    label: "Session recording",
+    helper:
+      "Let us replay your session when something breaks so we can diagnose and fix issues faster.",
+  },
+}
 
 export function ProfilePage() {
   const auth = useAuth()
+  const search = ProfileRoute.useSearch()
+  const privacySectionRef = useRef<HTMLDivElement>(null)
   const [showConfirm, setShowConfirm] = useState(false)
   const [confirmEmail, setConfirmEmail] = useState("")
   const [isDeleting, setIsDeleting] = useState(false)
+  const [savingConsentType, setSavingConsentType] =
+    useState<ConsentType | null>(null)
+
+  const stale = hasStaleConsent(auth.consents)
+  const showStaleBanner = stale || search.reason === "consent-stale"
+
+  useEffect(() => {
+    if (showStaleBanner && privacySectionRef.current) {
+      privacySectionRef.current.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      })
+    }
+  }, [showStaleBanner])
 
   async function handleDelete(e: React.FormEvent) {
     e.preventDefault()
@@ -33,8 +75,34 @@ export function ProfilePage() {
     }
   }
 
+  async function handleConsentChange(type: ConsentType, consented: boolean) {
+    setSavingConsentType(type)
+    try {
+      // Re-submitting the other known type with its current value (or false
+      // if unset) keeps the append-only history coherent: every change is a
+      // single POST capturing the full decision set at that moment.
+      const entries: ConsentInput[] = (
+        Object.keys(CONSENT_COPY) as ConsentType[]
+      ).map((t) => ({
+        type: t,
+        consented:
+          t === type
+            ? consented
+            : (auth.consents?.consents[t]?.consented ?? false),
+      }))
+      const response = await submitConsents(entries)
+      auth.setConsents(response)
+      toast.success("Saved. Takes effect on next page reload.")
+    } catch (error) {
+      const message = await getErrorMessage(error, "Failed to save consent")
+      toast.error(message)
+    } finally {
+      setSavingConsentType(null)
+    }
+  }
+
   return (
-    <div className="flex flex-1 items-center justify-center px-4">
+    <div className="flex flex-1 items-center justify-center px-4 py-8">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <div className="mx-auto mb-2">
@@ -44,10 +112,73 @@ export function ProfilePage() {
             Profile
           </CardTitle>
         </CardHeader>
-        <CardContent className="grid gap-4">
+        <CardContent className="grid gap-6">
           <div className="grid gap-1 text-sm">
             <span className="text-muted-foreground">Email</span>
             <span>{auth.email}</span>
+          </div>
+
+          <div
+            ref={privacySectionRef}
+            className="grid gap-3 border-t pt-4"
+            data-testid="privacy-section"
+          >
+            <h3 className="text-sm font-semibold">Privacy and data</h3>
+            {showStaleBanner && (
+              <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs leading-relaxed">
+                <p className="mb-1 font-semibold text-amber-200">
+                  Privacy policy updated
+                </p>
+                <p className="text-muted-foreground">
+                  Our privacy policy was updated. Please review your choices
+                  below — submitting any change (or keeping them as-is)
+                  acknowledges the new version.
+                </p>
+              </div>
+            )}
+            {(Object.keys(CONSENT_COPY) as ConsentType[]).map((type) => {
+              const entry = auth.consents?.consents[type]
+              const checked = entry?.consented ?? false
+              const isSaving = savingConsentType === type
+              return (
+                <label
+                  key={type}
+                  className="flex cursor-pointer items-start gap-3"
+                >
+                  <Checkbox
+                    checked={checked}
+                    onCheckedChange={(next) =>
+                      handleConsentChange(type, next === true)
+                    }
+                    disabled={isSaving}
+                    className="mt-0.5 shrink-0"
+                  />
+                  <span className="text-xs leading-relaxed">
+                    <span className="font-medium">
+                      {CONSENT_COPY[type].label}
+                      {isSaving && (
+                        <LoaderCircle className="ml-1 inline size-3 animate-spin" />
+                      )}
+                    </span>
+                    <br />
+                    <span className="text-muted-foreground">
+                      {CONSENT_COPY[type].helper}
+                    </span>
+                  </span>
+                </label>
+              )
+            })}
+            <p className="text-muted-foreground text-xs">
+              Changes take effect on your next page reload.{" "}
+              <a
+                href="https://criticalbit.gg/privacy"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary underline"
+              >
+                Learn more
+              </a>
+            </p>
           </div>
 
           <div className="border-destructive/30 bg-destructive/5 rounded-md border p-4">

--- a/src/pages/register/register-page.tsx
+++ b/src/pages/register/register-page.tsx
@@ -16,12 +16,15 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { api } from "@/api/api"
 import { getErrorMessage } from "@/lib/api-errors"
+import { submitConsents, type ConsentInput } from "@/lib/consent"
 
 export function RegisterPage() {
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
   const [tosAccepted, setTosAccepted] = useState(false)
+  const [analyticsConsent, setAnalyticsConsent] = useState(false)
+  const [sessionReplayConsent, setSessionReplayConsent] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   async function handleSubmit(e: React.FormEvent) {
@@ -50,6 +53,19 @@ export function RegisterPage() {
       })
       // Record ToS acceptance while authenticated
       await api.post("auth/accept-tos")
+      // Record initial consent decisions. Always POST both types (even when
+      // off) so we have an explicit audit trail of the user's opt-out, not
+      // just "no row yet". Failure here shouldn't block signup — the user
+      // can retry from the profile page.
+      const consents: ConsentInput[] = [
+        { type: "analytics", consented: analyticsConsent },
+        { type: "session_replay", consented: sessionReplayConsent },
+      ]
+      try {
+        await submitConsents(consents)
+      } catch {
+        // Swallow — user is signed up; they'll be prompted again on profile.
+      }
       window.location.href = "/profile"
     } catch (error) {
       const message = await getErrorMessage(error, "Registration failed")
@@ -132,6 +148,51 @@ export function RegisterPage() {
                 </a>
               </span>
             </label>
+            <div className="grid gap-3 border-t pt-4">
+              <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                Help us improve (optional)
+              </p>
+              <label className="flex cursor-pointer items-start gap-3">
+                <Checkbox
+                  checked={analyticsConsent}
+                  onCheckedChange={(checked) =>
+                    setAnalyticsConsent(checked === true)
+                  }
+                  disabled={isSubmitting}
+                  className="mt-0.5 shrink-0"
+                />
+                <span className="text-muted-foreground text-xs leading-relaxed">
+                  Help us understand how the site is used. Enables analytics
+                  cookies so we can see which features people use across
+                  sessions.
+                </span>
+              </label>
+              <label className="flex cursor-pointer items-start gap-3">
+                <Checkbox
+                  checked={sessionReplayConsent}
+                  onCheckedChange={(checked) =>
+                    setSessionReplayConsent(checked === true)
+                  }
+                  disabled={isSubmitting}
+                  className="mt-0.5 shrink-0"
+                />
+                <span className="text-muted-foreground text-xs leading-relaxed">
+                  Allow session recording for debugging. Lets us replay your
+                  session when something breaks to help fix it faster.
+                </span>
+              </label>
+              <p className="text-muted-foreground text-xs">
+                You can change these anytime from your profile.{" "}
+                <a
+                  href="https://criticalbit.gg/privacy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline"
+                >
+                  Learn more
+                </a>
+              </p>
+            </div>
             <Button
               type="submit"
               className="w-full"

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -3,6 +3,7 @@ import { QueryClient } from "@tanstack/react-query"
 import {
   createRootRouteWithContext,
   Outlet,
+  redirect,
   useRouter,
 } from "@tanstack/react-router"
 import { Toaster } from "sonner"
@@ -11,6 +12,7 @@ import { Footer } from "@/components/footer"
 import { Navbar } from "@/components/navbar"
 import { NotFound } from "@/components/not-found"
 import { useAnalytics } from "@/lib/analytics"
+import { hasStaleConsent, type ConsentsResponse } from "@/lib/consent"
 
 const TanStackRouterDevtools = import.meta.env.PROD
   ? () => null
@@ -38,13 +40,33 @@ interface RouterContext {
     displayName: string | null
     avatarUrl: string | null
     tosAcceptedAt: string | null
+    consents: ConsentsResponse | null
     login: (email: string) => void
     logout: () => Promise<void>
     checkAuth: () => Promise<void>
+    setConsents: (consents: ConsentsResponse) => void
   }
 }
 
+// Routes that must never be hijacked by the stale-consent redirect:
+// /profile is the redirect target itself, and /callback/* handles in-flight
+// OAuth exchanges where interrupting the navigation would break sign-in.
+const CONSENT_REDIRECT_SKIP_PREFIXES = ["/profile", "/callback"]
+
 export const Route = createRootRouteWithContext<RouterContext>()({
+  beforeLoad: ({ context, location }) => {
+    if (!context.auth.isAuthenticated) return
+    const skip = CONSENT_REDIRECT_SKIP_PREFIXES.some((prefix) =>
+      location.pathname.startsWith(prefix)
+    )
+    if (skip) return
+    if (hasStaleConsent(context.auth.consents)) {
+      throw redirect({
+        to: "/profile",
+        search: { reason: "consent-stale" as const },
+      })
+    }
+  },
   component: RootComponent,
   notFoundComponent: NotFound,
   errorComponent: RootErrorComponent,

--- a/src/routes/profile.tsx
+++ b/src/routes/profile.tsx
@@ -1,7 +1,15 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
 import { ProfilePage } from "@/pages/profile/profile-page"
 
+interface ProfileSearch {
+  reason?: "consent-stale"
+}
+
 export const Route = createFileRoute("/profile")({
+  validateSearch: (search: Record<string, unknown>): ProfileSearch => {
+    const reason = search.reason
+    return reason === "consent-stale" ? { reason } : {}
+  },
   beforeLoad: ({ context }) => {
     if (!context.auth.isAuthenticated) {
       throw redirect({ to: "/login" })

--- a/src/test/renderers.tsx
+++ b/src/test/renderers.tsx
@@ -1,6 +1,7 @@
 import { ThemeProvider } from "@/components/theme-provider"
 import { AnalyticsProvider } from "@/lib/analytics"
 import { AuthProvider } from "@/lib/auth"
+import type { ConsentsResponse } from "@/lib/consent"
 import { FeatureFlagProvider } from "@/lib/feature-flags"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import {
@@ -24,9 +25,11 @@ interface RenderWithFileRoutesOptions extends Omit<RenderOptions, "wrapper"> {
       displayName: string | null
       avatarUrl: string | null
       tosAcceptedAt: string | null
+      consents: ConsentsResponse | null
       login: (email: string) => void
       logout: () => Promise<void>
       checkAuth: () => Promise<void>
+      setConsents: (consents: ConsentsResponse) => void
     }
   }
 }
@@ -39,9 +42,11 @@ const defaultAuth = {
   displayName: null,
   avatarUrl: null,
   tosAcceptedAt: null,
+  consents: null,
   login: () => {},
   logout: async () => {},
   checkAuth: async () => {},
+  setConsents: () => {},
 }
 
 export async function renderWithFileRoutes(


### PR DESCRIPTION
## Summary
- **Signup form**: adds an optional "Help us improve" section with independent checkboxes for \`analytics\` and \`session_replay\`, visually separated from the ToS block. Button stays gated only on ToS. On submit, register → login → accept-tos → \`POST /user/consents\` with both decisions (including explicit opt-outs for a clean audit trail).
- **Profile page**: new "Privacy and data" section with per-purpose toggles, toast on save ("Takes effect on next page reload"), and an amber banner when re-prompted after a policy version bump.
- **Re-prompt mechanism**: root-level \`beforeLoad\` guard in \`__root.tsx\` redirects authenticated users with any \`is_stale\` consent to \`/profile?reason=consent-stale\`. Allow-list for \`/profile\` and \`/callback/*\` so the target page itself and in-flight OAuth can't be hijacked.
- **Auth context**: \`checkAuth()\` hydrates consents alongside \`/auth/me\`. Consent fetch failure is non-fatal — user stays logged in and the guard treats null consents as "nothing stale" so the app stays usable under degraded conditions.

No dedicated \`/consent-update\` route. Consent is optional by definition (the user can use the service without it), so it doesn't need the same blocking treatment as ToS re-acceptance. Folding everything into the profile page is intentional and legally well-defended.

Depends on criticalbit-auth-api#19 (shipped) for the consent endpoints. Paired with criticalbit-web#13 (shipped) which exposes the ISO policy version string in the privacy policy.

## Test plan
- [x] \`pnpm build\` (\`tsc -b\` + vite build) — clean
- [x] \`pnpm lint\` — 4 pre-existing warnings in \`__root.tsx\` (fast-refresh), no new issues
- [x] \`pnpm format:check\` — clean
- [x] \`pnpm test:run\` — 2/2 pass
- [x] Dev server boots; \`/register\` and \`/login\` return 200
- [ ] Manual: register a fresh account with both consents ticked → profile page shows them on. Untick one → POST succeeds, toast appears, reload → choice persisted.
- [ ] Manual: with authenticated user, seed a stale consent row in the DB → next page load redirects to \`/profile?reason=consent-stale\`, banner renders, re-submitting clears the stale state.
- [ ] Manual: consent fetch 500 → user stays logged in and app remains usable (guard sees null consents, no redirect).