### PR TITLE
chore: replace <strong> with Tailwind font-semibold span

### DIFF
--- a/src/pages/profile/profile-page.tsx
+++ b/src/pages/profile/profile-page.tsx
@@ -193,7 +193,8 @@ export function ProfilePage() {
                 </p>
                 <div className="grid gap-1">
                   <Label htmlFor="confirm-delete" className="text-xs">
-                    Type <strong>DELETE</strong> to confirm
+                    Type <span className="font-semibold">DELETE</span> to
+                    confirm
                   </Label>
                   <Input
                     id="confirm-delete"


### PR DESCRIPTION
## Summary
Drive-by cleanup: the delete-account confirmation label used \`<strong>DELETE</strong>\` for visual weight. The user's typed keyword "DELETE" gets the same bold treatment via \`<span className=\"font-semibold\">\` instead, matching the Tailwind-first styling convention used everywhere else in this codebase.

Paired with the same cleanup in criticalbit-web#14 — a global project preference to stop using \`<strong>\` for visual weight.

One worth-flagging nuance: \`<strong>\` does have legitimate screen-reader value when used for actual emphasis in running prose (a narrator voice stresses the word). In "Type **DELETE** to confirm", the keyword arguably benefits from that emphasis — a blind user benefits from hearing it stressed. But the broader project preference is "pretty much never use \`<strong>\`", and if this one specific case turns out to matter we can revisit with an \`<code>\` alternative (literal-keyword semantic) rather than bringing \`<strong>\` back.

## Test plan
- [x] \`pnpm build\` — clean
- [x] \`pnpm lint\` — 4 pre-existing warnings, no new issues
- [x] \`pnpm format:check\` — clean
- [ ] Visual check: "Type DELETE to confirm" still bolds "DELETE" on the profile delete flow