### PR TITLE
feat(loading): replace blank flash with app shell skeleton

### DIFF
--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("bg-muted animate-pulse rounded-md", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,7 @@ import { toast } from "sonner"
 import "@fontsource-variable/geist"
 import { ThemeProvider } from "./components/theme-provider"
 import "./index.css"
+import { Skeleton } from "./components/ui/skeleton"
 import { AnalyticsProvider, createAnalyticsBackend } from "./lib/analytics"
 import { getErrorMessage } from "./lib/api-errors"
 import { AuthProvider, useAuth } from "./lib/auth"
@@ -62,9 +63,40 @@ declare module "@tanstack/react-query" {
   }
 }
 
+function AppShellSkeleton() {
+  return (
+    <>
+      <nav className="border-border/50 bg-background/80 fixed top-0 z-50 w-full border-b backdrop-blur-sm">
+        <div className="flex h-14 items-center justify-between px-4">
+          <span className="font-pixel text-lg tracking-wide">CriticalBit</span>
+          <div className="flex items-center gap-2">
+            <Skeleton className="size-8 rounded-md" />
+            <Skeleton className="size-8 rounded-md" />
+          </div>
+        </div>
+      </nav>
+      <div className="flex min-h-screen items-center justify-center px-4 pt-14">
+        <div className="w-full max-w-sm space-y-6 rounded-lg border p-6">
+          <div className="flex flex-col items-center gap-3">
+            <Skeleton className="size-16 rounded-full" />
+            <Skeleton className="h-6 w-32" />
+          </div>
+          <div className="space-y-3">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-9 w-full" />
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-9 w-full" />
+          </div>
+          <Skeleton className="h-9 w-full" />
+        </div>
+      </div>
+    </>
+  )
+}
+
 function App() {
   const auth = useAuth()
-  if (auth.isLoading) return null
+  if (auth.isLoading) return <AppShellSkeleton />
   return <RouterProvider router={router} context={{ auth }} />
 }
 


### PR DESCRIPTION
## Summary

Adds an \`AppShellSkeleton\` that's rendered while \`auth.isLoading === true\`, replacing the previous \`return null\`. Users now see a stable navbar shape plus a centered card placeholder (matching the login/register/profile form shape) instead of a blank screen between page load and auth resolution.

The skeleton's nav matches the real navbar's height (\`h-14\`) and brand text (\`CriticalBit\` in \`font-pixel\`), so there's no layout shift when the real navbar mounts. The card content (avatar + title + label/input ×2 + submit button) approximates the shape of the auth forms users land on.

Also adds the shadcn \`Skeleton\` primitive (\`src/components/ui/skeleton.tsx\`) since this repo didn't have it yet.

## Test plan

- [x] \`pnpm lint\` — 0 errors, 6 warnings (pre-existing baseline)
- [x] \`pnpm build\` — clean
- [ ] CI green
- [ ] Netlify deploy preview shows the skeleton briefly on initial load instead of a blank screen