### PR TITLE
refactor: move error and not-found components to router defaults

### DIFF
--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 import { logger } from "@/lib/logger"
 import { captureException } from "@/lib/sentry"
 
-export function RootErrorComponent({ error, reset }: ErrorComponentProps) {
+export function ErrorBoundary({ error, reset }: ErrorComponentProps) {
   logger.error("Uncaught error in route component", {
     message: error.message,
     stack: error.stack,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,8 @@ import { reactErrorHandler } from "@sentry/react"
 import { toast } from "sonner"
 // @ts-expect-error -- fontsource CSS-only import, no types
 import "@fontsource-variable/geist"
+import { ErrorBoundary } from "./components/error-boundary"
+import { NotFound } from "./components/not-found"
 import { ThemeProvider } from "./components/theme-provider"
 import "./index.css"
 import { Skeleton } from "./components/ui/skeleton"
@@ -45,6 +47,8 @@ const router = createRouter({
   },
   defaultPreload: "intent",
   defaultPreloadStaleTime: 0,
+  defaultNotFoundComponent: NotFound,
+  defaultErrorComponent: ErrorBoundary,
 })
 
 initSentry(router)

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -7,10 +7,8 @@ import {
   useRouter,
 } from "@tanstack/react-router"
 import { Toaster } from "sonner"
-import { RootErrorComponent } from "@/components/error-boundary"
 import { Footer } from "@/components/footer"
 import { Navbar } from "@/components/navbar"
-import { NotFound } from "@/components/not-found"
 import { useAnalytics } from "@/lib/analytics"
 import { hasStaleConsent, type ConsentsResponse } from "@/lib/consent"
 
@@ -68,8 +66,6 @@ export const Route = createRootRouteWithContext<RouterContext>()({
     }
   },
   component: RootComponent,
-  notFoundComponent: NotFound,
-  errorComponent: RootErrorComponent,
 })
 
 function RouteTracker() {


### PR DESCRIPTION
## Summary
- Register the error boundary and not-found component on the router via `defaultErrorComponent` / `defaultNotFoundComponent` in `main.tsx` instead of on the root route. This lets the boundary catch errors thrown by the root route itself.
- Rename `RootErrorComponent` → `ErrorBoundary` so the export matches the `error-boundary.tsx` filename.

## Test plan
- [ ] `pnpm dev` — app boots normally
- [ ] Visit a bogus path — 404 page renders
- [ ] Throw inside a route component — error page renders
- [ ] `pnpm build` and `pnpm test:run` both pass