### PR TITLE
test(navbar): guard display_name rendering against rename regressions

### DIFF
--- a/src/components/navbar.test.tsx
+++ b/src/components/navbar.test.tsx
@@ -1,0 +1,94 @@
+import { screen } from "@testing-library/react"
+import { http, HttpResponse } from "msw"
+import { describe, expect, it } from "vitest"
+import { renderWithFileRoutes } from "@/test/renderers"
+import { server } from "@/test/setup"
+
+// Regression guard for criticalbit-web#23 (recurring): the navbar must
+// render the human-readable display_name returned by /auth/me, never the
+// raw user id (which for Steam OAuth is the SteamID64). The actual root
+// cause of the linked bug lives in criticalbit-auth-api (#26) — but this
+// test pins the *frontend* contract so a rename like `display_name` →
+// `displayName`, a dropped setDisplayName call, or a navbar swap to
+// userId/email can't silently reintroduce the same visible regression
+// here.
+
+const STEAM_ID = "76561198000000000"
+
+const unauthContext = {
+  auth: {
+    isAuthenticated: false,
+    isLoading: false,
+    email: null,
+    userId: null,
+    displayName: null,
+    avatarUrl: null,
+    tosAcceptedAt: null,
+    consents: null,
+    login: () => {},
+    logout: async () => {},
+    checkAuth: async () => {},
+    setConsents: () => {},
+  },
+}
+
+function authMeHandler(body: {
+  id: string
+  email: string
+  display_name: string | null
+  avatar_url: string | null
+  tos_accepted_at: string | null
+}) {
+  return http.get("*/auth/me", () => HttpResponse.json(body))
+}
+
+// The consent fetch fires right after /auth/me succeeds. Stub it so the
+// AuthProvider's catch-all doesn't surface as an unhandled-request warning.
+const consentsHandler = http.get("*/user/consents", () =>
+  HttpResponse.json({ current_policy_version: "test", consents: {} })
+)
+
+describe("Navbar", () => {
+  it("renders the Steam display_name, not the SteamID64", async () => {
+    server.use(
+      authMeHandler({
+        id: STEAM_ID,
+        email: "player@example.com",
+        display_name: "ZeroEmpires",
+        avatar_url: null,
+        tos_accepted_at: null,
+      }),
+      consentsHandler
+    )
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/login",
+      routerContext: unauthContext,
+    })
+
+    expect(await screen.findByText("ZeroEmpires")).toBeInTheDocument()
+    expect(screen.queryByText(STEAM_ID)).not.toBeInTheDocument()
+    expect(screen.queryByText("player@example.com")).not.toBeInTheDocument()
+  })
+
+  it("falls back to email when display_name is null", async () => {
+    server.use(
+      authMeHandler({
+        id: STEAM_ID,
+        email: "player@example.com",
+        display_name: null,
+        avatar_url: null,
+        tos_accepted_at: null,
+      }),
+      consentsHandler
+    )
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/login",
+      routerContext: unauthContext,
+    })
+
+    expect(await screen.findByText("player@example.com")).toBeInTheDocument()
+    expect(screen.queryByText(STEAM_ID)).not.toBeInTheDocument()
+  })
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -4,7 +4,7 @@ import { cleanup } from "@testing-library/react"
 import { setupServer } from "msw/node"
 import { afterAll, afterEach, beforeAll, vi } from "vitest"
 
-const server = setupServer(...handlers)
+export const server = setupServer(...handlers)
 
 beforeAll(() => server.listen())
 afterAll(() => server.close())

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
     environment: "jsdom",
     env: {
       VITE_LOG_LEVEL: "warn",
+      // ky/undici reject relative URLs as unparseable. Without an absolute
+      // base, /auth/me requests in tests throw before reaching MSW and the
+      // AuthProvider's catch swallows the failure — tests appear to pass
+      // while every API call silently 500s.
+      VITE_API_URL: "http://localhost/api",
     },
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.{test,spec}.{ts,tsx}"],


### PR DESCRIPTION
## Summary

- Adds a frontend regression guard so a rename or accidental swap (`display_name` → `displayName`, swapping `userId` into the navbar, etc.) cannot silently reintroduce the "Steam profile name regression" — where the navbar surfaces the raw SteamID64 instead of the human-readable name.
- The actual root cause for the linked bug lives upstream in **ag-tech-group/criticalbit-auth-api#26**. The sibling hub frontend already shipped this exact guard in **ag-tech-group/criticalbit-web#23**; this PR mirrors it here because `src/lib/auth.tsx` and `src/components/navbar.tsx` consume the same `/auth/me` shape and have the same rendering chain (`auth.displayName ?? auth.email`).
- Fixes a latent test-infra bug at the same time: without an absolute `VITE_API_URL`, ky/undici reject `/api/...` as unparseable, the `AuthProvider`'s catch swallows the failure, and tests appear to pass while every `/auth/me` call silently 500s. Mirrors the same fix in criticalbit-web#23.

## Changes

- `src/components/navbar.test.tsx` — two assertions: (1) navbar renders `display_name` from `/auth/me`, not the SteamID64 or the email; (2) it falls back to email when `display_name` is null.
- `src/test/setup.ts` — exports the MSW `server` instance so tests can do per-test handler overrides via `server.use(...)`.
- `vitest.config.ts` — sets `VITE_API_URL=http://localhost/api` in `test.env` so MSW can actually intercept.

## Mutation check

To prove the guard catches the regression, I temporarily changed `setDisplayName(user.display_name)` in `src/lib/auth.tsx` to read a renamed `(user as ...).displayName` field. The first navbar test then fails (navbar falls back to email, "ZeroEmpires" never appears). Reverted before commit.

## Notes on this repo vs. criticalbit-web

- `/auth/me` here also returns `tos_accepted_at` — included in the mocked payload.
- The navbar here only renders the user dropdown when `auth.isAuthenticated` (no "Sign in" button — sign-in lives at `/login`). The display_name assertion still works the same way; the test waits for the post-`/auth/me` re-render.
- The render helper here already wraps in `AnalyticsProvider` + `FeatureFlagProvider`; neither fetches on mount in a way that interferes.

## Test plan

- [x] `pnpm test:run` — passes (4 tests across 2 files).
- [x] `pnpm lint` — 0 errors (6 pre-existing warnings in untouched files).
- [x] Mutation check on `src/lib/auth.tsx` — first navbar test fails on the rename, reverted.
- [ ] CI green.