### PR TITLE
feat(profile): add display name input wired to PATCH /auth/me

### DIFF
--- a/src/pages/profile/profile-page.test.tsx
+++ b/src/pages/profile/profile-page.test.tsx
@@ -1,0 +1,212 @@
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { http, HttpResponse } from "msw"
+import { describe, expect, it, vi } from "vitest"
+import { renderWithFileRoutes } from "@/test/renderers"
+import { server } from "@/test/setup"
+
+vi.mock("sonner", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("sonner")>()
+  return {
+    ...actual,
+    toast: {
+      ...actual.toast,
+      success: vi.fn(),
+      error: vi.fn(),
+    },
+  }
+})
+
+import { toast } from "sonner"
+
+type AuthMeBody = {
+  id: string
+  email: string
+  display_name: string | null
+  avatar_url: string | null
+  tos_accepted_at: string | null
+}
+
+const consentsHandler = http.get("*/user/consents", () =>
+  HttpResponse.json({ current_policy_version: "test", consents: {} })
+)
+
+function authMeHandler(initial: AuthMeBody) {
+  let current = initial
+  return {
+    setBody(next: AuthMeBody) {
+      current = next
+    },
+    handler: http.get("*/auth/me", () => HttpResponse.json(current)),
+  }
+}
+
+describe("ProfilePage display name", () => {
+  it("pre-fills the input with the current display_name", async () => {
+    const me = authMeHandler({
+      id: "u-1",
+      email: "player@example.com",
+      display_name: "ZeroEmpires",
+      avatar_url: null,
+      tos_accepted_at: "2026-01-01T00:00:00Z",
+    })
+    server.use(me.handler, consentsHandler)
+
+    await renderWithFileRoutes(<></>, { initialLocation: "/profile" })
+
+    const input = await screen.findByLabelText<HTMLInputElement>("Display name")
+    await waitFor(() => expect(input.value).toBe("ZeroEmpires"))
+  })
+
+  it("renders an empty input when display_name is unset", async () => {
+    const me = authMeHandler({
+      id: "u-1",
+      email: "player@example.com",
+      display_name: null,
+      avatar_url: null,
+      tos_accepted_at: "2026-01-01T00:00:00Z",
+    })
+    server.use(me.handler, consentsHandler)
+
+    await renderWithFileRoutes(<></>, { initialLocation: "/profile" })
+
+    const input = await screen.findByLabelText<HTMLInputElement>("Display name")
+    await waitFor(() => expect(input.value).toBe(""))
+  })
+
+  it("PATCHes /auth/me with the trimmed value and toasts on success", async () => {
+    const me = authMeHandler({
+      id: "u-1",
+      email: "player@example.com",
+      display_name: null,
+      avatar_url: null,
+      tos_accepted_at: "2026-01-01T00:00:00Z",
+    })
+    let captured: { display_name?: unknown } | null = null
+    server.use(
+      me.handler,
+      consentsHandler,
+      http.patch("*/auth/me", async ({ request }) => {
+        captured = (await request.json()) as { display_name?: unknown }
+        me.setBody({
+          id: "u-1",
+          email: "player@example.com",
+          display_name: "ZeroEmpires",
+          avatar_url: null,
+          tos_accepted_at: "2026-01-01T00:00:00Z",
+        })
+        return HttpResponse.json({ ok: true })
+      })
+    )
+
+    await renderWithFileRoutes(<></>, { initialLocation: "/profile" })
+
+    const user = userEvent.setup()
+    const input = await screen.findByLabelText<HTMLInputElement>("Display name")
+    await user.type(input, "  ZeroEmpires  ")
+    await user.click(screen.getByRole("button", { name: /save display name/i }))
+
+    await waitFor(() => expect(captured).not.toBeNull())
+    expect(captured).toEqual({ display_name: "ZeroEmpires" })
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith("Display name updated.")
+    )
+  })
+
+  it("sends an empty string when the user clears the field", async () => {
+    const me = authMeHandler({
+      id: "u-1",
+      email: "player@example.com",
+      display_name: "ZeroEmpires",
+      avatar_url: null,
+      tos_accepted_at: "2026-01-01T00:00:00Z",
+    })
+    let captured: { display_name?: unknown } | null = null
+    server.use(
+      me.handler,
+      consentsHandler,
+      http.patch("*/auth/me", async ({ request }) => {
+        captured = (await request.json()) as { display_name?: unknown }
+        me.setBody({
+          id: "u-1",
+          email: "player@example.com",
+          display_name: null,
+          avatar_url: null,
+          tos_accepted_at: "2026-01-01T00:00:00Z",
+        })
+        return HttpResponse.json({ ok: true })
+      })
+    )
+
+    await renderWithFileRoutes(<></>, { initialLocation: "/profile" })
+
+    const user = userEvent.setup()
+    const input = await screen.findByLabelText<HTMLInputElement>("Display name")
+    await waitFor(() => expect(input.value).toBe("ZeroEmpires"))
+
+    await user.clear(input)
+    await user.click(
+      screen.getByRole("button", { name: /clear display name/i })
+    )
+
+    await waitFor(() => expect(captured).not.toBeNull())
+    expect(captured).toEqual({ display_name: "" })
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith("Display name cleared.")
+    )
+  })
+
+  it("surfaces backend 422 messages as an error toast", async () => {
+    const me = authMeHandler({
+      id: "u-1",
+      email: "player@example.com",
+      display_name: null,
+      avatar_url: null,
+      tos_accepted_at: "2026-01-01T00:00:00Z",
+    })
+    server.use(
+      me.handler,
+      consentsHandler,
+      http.patch("*/auth/me", () =>
+        HttpResponse.json(
+          { detail: "Display name is too long." },
+          { status: 422 }
+        )
+      )
+    )
+
+    await renderWithFileRoutes(<></>, { initialLocation: "/profile" })
+
+    const user = userEvent.setup()
+    const input = await screen.findByLabelText<HTMLInputElement>("Display name")
+    await user.type(input, "anything")
+    await user.click(screen.getByRole("button", { name: /save display name/i }))
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("Display name is too long.")
+    )
+  })
+
+  it("disables the save button when the trimmed value equals the current name", async () => {
+    const me = authMeHandler({
+      id: "u-1",
+      email: "player@example.com",
+      display_name: "ZeroEmpires",
+      avatar_url: null,
+      tos_accepted_at: "2026-01-01T00:00:00Z",
+    })
+    server.use(me.handler, consentsHandler)
+
+    await renderWithFileRoutes(<></>, { initialLocation: "/profile" })
+
+    const input = await screen.findByLabelText<HTMLInputElement>("Display name")
+    await waitFor(() => expect(input.value).toBe("ZeroEmpires"))
+
+    const button = screen.getByRole("button", { name: /save display name/i })
+    expect(button).toBeDisabled()
+
+    const user = userEvent.setup()
+    await user.type(input, "   ")
+    expect(button).toBeDisabled()
+  })
+})

--- a/src/pages/profile/profile-page.tsx
+++ b/src/pages/profile/profile-page.tsx
@@ -36,6 +36,8 @@ const CONSENT_COPY: Record<ConsentType, ConsentToggleCopy> = {
   },
 }
 
+const DISPLAY_NAME_MAX_LENGTH = 100
+
 export function ProfilePage() {
   const auth = useAuth()
   const search = ProfileRoute.useSearch()
@@ -45,9 +47,19 @@ export function ProfilePage() {
   const [isDeleting, setIsDeleting] = useState(false)
   const [savingConsentType, setSavingConsentType] =
     useState<ConsentType | null>(null)
+  const [displayName, setDisplayName] = useState(auth.displayName ?? "")
+  const [isSavingDisplayName, setIsSavingDisplayName] = useState(false)
+
+  useEffect(() => {
+    setDisplayName(auth.displayName ?? "")
+  }, [auth.displayName])
 
   const stale = hasStaleConsent(auth.consents)
   const showStaleBanner = stale || search.reason === "consent-stale"
+
+  const trimmedDisplayName = displayName.trim()
+  const currentDisplayName = auth.displayName ?? ""
+  const displayNameChanged = trimmedDisplayName !== currentDisplayName
 
   useEffect(() => {
     if (showStaleBanner && privacySectionRef.current) {
@@ -57,6 +69,28 @@ export function ProfilePage() {
       })
     }
   }, [showStaleBanner])
+
+  async function handleDisplayNameSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!displayNameChanged || isSavingDisplayName) return
+
+    setIsSavingDisplayName(true)
+    try {
+      await api.patch("auth/me", { json: { display_name: trimmedDisplayName } })
+      await auth.checkAuth()
+      toast.success(
+        trimmedDisplayName ? "Display name updated." : "Display name cleared."
+      )
+    } catch (error) {
+      const message = await getErrorMessage(
+        error,
+        "Failed to update display name"
+      )
+      toast.error(message)
+    } finally {
+      setIsSavingDisplayName(false)
+    }
+  }
 
   async function handleDelete(e: React.FormEvent) {
     e.preventDefault()
@@ -113,9 +147,43 @@ export function ProfilePage() {
           </CardTitle>
         </CardHeader>
         <CardContent className="grid gap-6">
-          <div className="grid gap-1 text-sm">
-            <span className="text-muted-foreground">Email</span>
-            <span>{auth.email}</span>
+          <div className="grid gap-4">
+            <div className="grid gap-1 text-sm">
+              <span className="text-muted-foreground">Email</span>
+              <span>{auth.email}</span>
+            </div>
+            <form
+              onSubmit={handleDisplayNameSubmit}
+              className="grid gap-2"
+              data-testid="display-name-form"
+            >
+              <Label htmlFor="display-name" className="text-muted-foreground">
+                Display name
+              </Label>
+              <Input
+                id="display-name"
+                type="text"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                maxLength={DISPLAY_NAME_MAX_LENGTH}
+                placeholder="How you'll appear across criticalbit.gg"
+                autoComplete="nickname"
+                disabled={isSavingDisplayName}
+              />
+              <Button
+                type="submit"
+                size="sm"
+                className="w-full"
+                disabled={!displayNameChanged || isSavingDisplayName}
+              >
+                {trimmedDisplayName || !currentDisplayName
+                  ? "Save display name"
+                  : "Clear display name"}
+                {isSavingDisplayName && (
+                  <LoaderCircle className="animate-spin" />
+                )}
+              </Button>
+            </form>
           </div>
 
           <div


### PR DESCRIPTION
## Summary
- Adds a labeled display-name input on `/profile`, pre-filled from `auth.displayName`.
- Submit trims the value and PATCHes `/auth/me`; empty input clears the name (matches backend normalisation).
- After save, re-syncs auth state via `checkAuth()` so the navbar updates without a reload. Success/error toasts.

Closes #35. Frontend-only — the backend already supports `display_name` on `PATCH /auth/me`, the profile UI just didn't expose it.

## Test plan
- [ ] Email/password user with no display name: open `/profile`, set a name, save → toast, navbar updates.
- [ ] Edit existing name, save → updated value persists.
- [ ] Clear the field → button label switches to "Clear display name", submitting toasts "Display name cleared." and the name disappears from navbar.
- [ ] Type only whitespace into a previously empty field → Save stays disabled.
- [ ] Backend returns 422 (e.g. paste 101+ chars before maxLength caps you, or have backend reject) → error toast surfaces the message.
- [ ] Steam OAuth user (display_name populated from Steam) sees their name pre-filled and can change it.