### PR TITLE
feat(accept-terms): collect email for users without one on file

### DIFF
--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -86,7 +86,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     try {
       const user = await api.get("auth/me").json<{
         id: string
-        email: string
+        email: string | null
         display_name: string | null
         avatar_url: string | null
         tos_accepted_at: string | null
@@ -97,7 +97,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setDisplayName(user.display_name)
       setAvatarUrl(user.avatar_url)
       setTosAcceptedAt(user.tos_accepted_at)
-      localStorage.setItem(EMAIL_KEY, user.email)
+      // Steam OAuth users start with no email until they pass /accept-terms;
+      // don't cache "null" as a string and don't leave a stale value behind.
+      if (user.email) {
+        localStorage.setItem(EMAIL_KEY, user.email)
+      } else {
+        localStorage.removeItem(EMAIL_KEY)
+      }
       // Consent hydration must not block auth — if the fetch fails the user
       // still appears logged in; the root guard treats null consents as
       // "nothing stale" so the app stays usable.

--- a/src/pages/accept-terms/accept-terms-page.test.tsx
+++ b/src/pages/accept-terms/accept-terms-page.test.tsx
@@ -1,0 +1,285 @@
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { http, HttpResponse } from "msw"
+import { describe, expect, it, vi } from "vitest"
+import { renderWithFileRoutes } from "@/test/renderers"
+import { server } from "@/test/setup"
+
+vi.mock("sonner", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("sonner")>()
+  return {
+    ...actual,
+    toast: {
+      ...actual.toast,
+      success: vi.fn(),
+      error: vi.fn(),
+    },
+  }
+})
+
+import { toast } from "sonner"
+
+type AuthMeBody = {
+  id: string
+  email: string | null
+  display_name: string | null
+  avatar_url: string | null
+  tos_accepted_at: string | null
+}
+
+const consentsHandler = http.get("*/user/consents", () =>
+  HttpResponse.json({ current_policy_version: "test", consents: {} })
+)
+
+function authMeHandler(body: AuthMeBody) {
+  return http.get("*/auth/me", () => HttpResponse.json(body))
+}
+
+function makeRouterAuth(overrides: {
+  email: string | null
+  tosAcceptedAt?: string | null
+}) {
+  return {
+    auth: {
+      isAuthenticated: true,
+      isLoading: false,
+      email: overrides.email,
+      userId: "u-1",
+      displayName: null,
+      avatarUrl: null,
+      tosAcceptedAt: overrides.tosAcceptedAt ?? null,
+      consents: null,
+      login: () => {},
+      logout: async () => {},
+      checkAuth: async () => {},
+      setConsents: () => {},
+    },
+  }
+}
+
+describe("AcceptTermsPage", () => {
+  it("renders the ToS-only flow for users who already have an email", async () => {
+    server.use(
+      authMeHandler({
+        id: "u-1",
+        email: "player@example.com",
+        display_name: null,
+        avatar_url: null,
+        tos_accepted_at: null,
+      }),
+      consentsHandler
+    )
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/accept-terms",
+      routerContext: makeRouterAuth({ email: "player@example.com" }),
+    })
+
+    expect(
+      await screen.findByText("Terms of Service", {
+        selector: "[data-slot='card-title']",
+      })
+    ).toBeInTheDocument()
+    expect(screen.queryByLabelText("Email")).not.toBeInTheDocument()
+  })
+
+  it("posts /auth/accept-tos with no body when the user already has an email", async () => {
+    const captured: { body: string | null } = { body: null }
+    server.use(
+      authMeHandler({
+        id: "u-1",
+        email: "player@example.com",
+        display_name: null,
+        avatar_url: null,
+        tos_accepted_at: null,
+      }),
+      consentsHandler,
+      http.post("*/auth/accept-tos", async ({ request }) => {
+        captured.body = await request.text()
+        return HttpResponse.json({
+          id: "u-1",
+          email: "player@example.com",
+          display_name: null,
+          avatar_url: null,
+          tos_accepted_at: new Date().toISOString(),
+        })
+      })
+    )
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/accept-terms",
+      routerContext: makeRouterAuth({ email: "player@example.com" }),
+    })
+
+    const user = userEvent.setup()
+    await user.click(await screen.findByRole("checkbox"))
+    await user.click(screen.getByRole("button", { name: /continue/i }))
+
+    await waitFor(() => expect(captured.body).not.toBeNull())
+    expect(captured.body).toBe("")
+  })
+
+  it("shows the email input + ToS checkbox for fresh users with no email", async () => {
+    server.use(
+      authMeHandler({
+        id: "u-1",
+        email: null,
+        display_name: "ZeroEmpires",
+        avatar_url: null,
+        tos_accepted_at: null,
+      }),
+      consentsHandler
+    )
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/accept-terms",
+      routerContext: makeRouterAuth({ email: null }),
+    })
+
+    expect(
+      await screen.findByText("Terms of Service", {
+        selector: "[data-slot='card-title']",
+      })
+    ).toBeInTheDocument()
+    expect(await screen.findByLabelText("Email")).toBeInTheDocument()
+    expect(screen.getByRole("checkbox")).toBeInTheDocument()
+  })
+
+  it("uses the backfill copy for users who accepted ToS but never set an email", async () => {
+    server.use(
+      authMeHandler({
+        id: "u-1",
+        email: null,
+        display_name: "ZeroEmpires",
+        avatar_url: null,
+        tos_accepted_at: "2026-01-01T00:00:00Z",
+      }),
+      consentsHandler
+    )
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/accept-terms",
+      routerContext: makeRouterAuth({
+        email: null,
+        tosAcceptedAt: "2026-01-01T00:00:00Z",
+      }),
+    })
+
+    expect(
+      await screen.findByText("One more thing", {
+        selector: "[data-slot='card-title']",
+      })
+    ).toBeInTheDocument()
+    expect(await screen.findByLabelText("Email")).toBeInTheDocument()
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument()
+  })
+
+  it("posts the trimmed lowercased email when the user submits", async () => {
+    let captured: { email?: unknown } | null = null
+    server.use(
+      authMeHandler({
+        id: "u-1",
+        email: null,
+        display_name: "ZeroEmpires",
+        avatar_url: null,
+        tos_accepted_at: null,
+      }),
+      consentsHandler,
+      http.post("*/auth/accept-tos", async ({ request }) => {
+        captured = (await request.json()) as { email?: unknown }
+        return HttpResponse.json({
+          id: "u-1",
+          email: "player@example.com",
+          display_name: "ZeroEmpires",
+          avatar_url: null,
+          tos_accepted_at: new Date().toISOString(),
+        })
+      })
+    )
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/accept-terms",
+      routerContext: makeRouterAuth({ email: null }),
+    })
+
+    const user = userEvent.setup()
+    const input = await screen.findByLabelText<HTMLInputElement>("Email")
+    await user.type(input, "  Player@Example.com  ")
+    await user.click(screen.getByRole("checkbox"))
+    await user.click(screen.getByRole("button", { name: /continue/i }))
+
+    await waitFor(() => expect(captured).not.toBeNull())
+    expect(captured).toEqual({ email: "player@example.com" })
+  })
+
+  it("renders an inline error and a sign-in CTA on 422 email_already_registered", async () => {
+    server.use(
+      authMeHandler({
+        id: "u-1",
+        email: null,
+        display_name: "ZeroEmpires",
+        avatar_url: null,
+        tos_accepted_at: null,
+      }),
+      consentsHandler,
+      http.post("*/auth/accept-tos", () =>
+        HttpResponse.json(
+          {
+            detail: {
+              code: "email_already_registered",
+              message:
+                "An account with that email already exists. Sign in to that account and link Steam from your profile.",
+            },
+          },
+          { status: 422 }
+        )
+      )
+    )
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/accept-terms",
+      routerContext: makeRouterAuth({ email: null }),
+    })
+
+    const user = userEvent.setup()
+    const input = await screen.findByLabelText<HTMLInputElement>("Email")
+    await user.type(input, "player@example.com")
+    await user.click(screen.getByRole("checkbox"))
+    await user.click(screen.getByRole("button", { name: /continue/i }))
+
+    expect(
+      await screen.findByText(/account with that email already exists/i)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /sign in with that account instead/i })
+    ).toBeInTheDocument()
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it("falls back to a toast for unstructured errors", async () => {
+    server.use(
+      authMeHandler({
+        id: "u-1",
+        email: "player@example.com",
+        display_name: null,
+        avatar_url: null,
+        tos_accepted_at: null,
+      }),
+      consentsHandler,
+      http.post("*/auth/accept-tos", () =>
+        HttpResponse.json({ detail: "boom" }, { status: 500 })
+      )
+    )
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/accept-terms",
+      routerContext: makeRouterAuth({ email: "player@example.com" }),
+    })
+
+    const user = userEvent.setup()
+    await user.click(await screen.findByRole("checkbox"))
+    await user.click(screen.getByRole("button", { name: /continue/i }))
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("boom"))
+  })
+})

--- a/src/pages/accept-terms/accept-terms-page.tsx
+++ b/src/pages/accept-terms/accept-terms-page.tsx
@@ -10,77 +10,186 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 import { api } from "@/api/api"
 import { getErrorMessage } from "@/lib/api-errors"
+import { useAuth } from "@/lib/auth"
+
+type AcceptTosErrorCode = "email_required" | "email_already_registered"
+
+interface AcceptTosErrorDetail {
+  code: AcceptTosErrorCode
+  message: string
+}
+
+async function parseAcceptTosError(
+  error: unknown
+): Promise<AcceptTosErrorDetail | null> {
+  const response = (error as { response?: Response })?.response
+  if (!response || response.status !== 422) return null
+  try {
+    const body = (await response.clone().json()) as {
+      detail?: { code?: unknown; message?: unknown }
+    }
+    const detail = body?.detail
+    if (
+      detail &&
+      typeof detail === "object" &&
+      typeof detail.code === "string" &&
+      typeof detail.message === "string"
+    ) {
+      return {
+        code: detail.code as AcceptTosErrorCode,
+        message: detail.message,
+      }
+    }
+  } catch {
+    // fall through to null — caller surfaces a generic toast
+  }
+  return null
+}
 
 export function AcceptTermsPage() {
-  const [accepted, setAccepted] = useState(false)
+  const auth = useAuth()
+  const needsEmail = !auth.email
+  const isBackfill = needsEmail && auth.tosAcceptedAt !== null
+
+  const [email, setEmail] = useState("")
+  const [accepted, setAccepted] = useState(isBackfill)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [emailError, setEmailError] = useState<AcceptTosErrorDetail | null>(
+    null
+  )
+
+  const trimmedEmail = email.trim()
+  const submitDisabled =
+    isSubmitting || !accepted || (needsEmail && trimmedEmail.length === 0)
+
+  async function handleSignInInstead() {
+    try {
+      await auth.logout()
+    } finally {
+      window.location.href = "/login"
+    }
+  }
 
   async function handleAccept(e: React.FormEvent) {
     e.preventDefault()
-    if (!accepted) return
+    if (submitDisabled) return
 
     setIsSubmitting(true)
+    setEmailError(null)
     try {
-      await api.post("auth/accept-tos")
+      const json = needsEmail
+        ? { email: trimmedEmail.toLowerCase() }
+        : undefined
+      await api.post("auth/accept-tos", json ? { json } : undefined)
       const savedRedirect = localStorage.getItem("auth_redirect")
       localStorage.removeItem("auth_redirect")
       window.location.href = savedRedirect ?? "/profile"
     } catch (error) {
-      const message = await getErrorMessage(error, "Failed to accept terms")
-      toast.error(message)
+      const detail = await parseAcceptTosError(error)
+      if (detail) {
+        setEmailError(detail)
+      } else {
+        const message = await getErrorMessage(error, "Failed to accept terms")
+        toast.error(message)
+      }
     } finally {
       setIsSubmitting(false)
     }
   }
+
+  const title = isBackfill ? "One more thing" : "Terms of Service"
+  const description = isBackfill
+    ? "We need a real email for your account before you can continue."
+    : "Please accept our terms to continue using criticalbit.gg"
 
   return (
     <div className="flex flex-1 items-center justify-center px-4">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <CardTitle className="font-pixel text-2xl tracking-wide">
-            Terms of Service
+            {title}
           </CardTitle>
-          <CardDescription>
-            Please accept our terms to continue using criticalbit.gg
-          </CardDescription>
+          <CardDescription>{description}</CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleAccept} className="grid gap-4">
-            <label className="flex cursor-pointer items-start gap-3">
-              <Checkbox
-                checked={accepted}
-                onCheckedChange={(checked) => setAccepted(checked === true)}
-                disabled={isSubmitting}
-                className="mt-0.5 shrink-0"
-              />
-              <span className="text-muted-foreground text-xs leading-relaxed">
-                I agree to the{" "}
-                <a
-                  href="https://criticalbit.gg/terms"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary underline"
+            {needsEmail && (
+              <div className="grid gap-2">
+                <Label htmlFor="steam-email">Email</Label>
+                <Input
+                  id="steam-email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => {
+                    setEmail(e.target.value)
+                    setEmailError(null)
+                  }}
+                  required
+                  autoComplete="email"
+                  placeholder="you@example.com"
+                  disabled={isSubmitting}
+                  aria-invalid={emailError !== null || undefined}
+                  aria-describedby="steam-email-helper"
+                />
+                <p
+                  id="steam-email-helper"
+                  className="text-muted-foreground text-xs leading-relaxed"
                 >
-                  Terms of Service
-                </a>{" "}
-                and{" "}
-                <a
-                  href="https://criticalbit.gg/privacy"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary underline"
-                >
-                  Privacy Policy
-                </a>
-              </span>
-            </label>
-            <Button
-              type="submit"
-              className="w-full"
-              disabled={isSubmitting || !accepted}
-            >
+                  Steam doesn&apos;t share your email with us, so we need one to
+                  send notifications and let you recover your account.
+                </p>
+                {emailError && (
+                  <div className="text-destructive grid gap-2 text-xs">
+                    <p>{emailError.message}</p>
+                    {emailError.code === "email_already_registered" && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={handleSignInInstead}
+                      >
+                        Sign in with that account instead
+                      </Button>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+            {!isBackfill && (
+              <label className="flex cursor-pointer items-start gap-3">
+                <Checkbox
+                  checked={accepted}
+                  onCheckedChange={(checked) => setAccepted(checked === true)}
+                  disabled={isSubmitting}
+                  className="mt-0.5 shrink-0"
+                />
+                <span className="text-muted-foreground text-xs leading-relaxed">
+                  I agree to the{" "}
+                  <a
+                    href="https://criticalbit.gg/terms"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline"
+                  >
+                    Terms of Service
+                  </a>{" "}
+                  and{" "}
+                  <a
+                    href="https://criticalbit.gg/privacy"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline"
+                  >
+                    Privacy Policy
+                  </a>
+                </span>
+              </label>
+            )}
+            <Button type="submit" className="w-full" disabled={submitDisabled}>
               Continue
               {isSubmitting && <LoaderCircle className="animate-spin" />}
             </Button>

--- a/src/pages/callback/oauth-complete-page.tsx
+++ b/src/pages/callback/oauth-complete-page.tsx
@@ -8,12 +8,14 @@ export function OAuthCompletePage() {
     if (calledRef.current) return
     calledRef.current = true
 
-    // Check if user has accepted ToS
     api
       .get("auth/me")
-      .json<{ tos_accepted_at: string | null }>()
+      .json<{ email: string | null; tos_accepted_at: string | null }>()
       .then((user) => {
-        if (!user.tos_accepted_at) {
+        // Steam OAuth users start with no email until they pass through
+        // /accept-terms (auth-api #36, auth-web #36) — route them there
+        // even if they previously accepted the old TOS-only gate.
+        if (!user.tos_accepted_at || !user.email) {
           // Keep the redirect in localStorage — accept-terms page will use it
           window.location.href = "/accept-terms"
         } else {

--- a/src/routes/__root.test.tsx
+++ b/src/routes/__root.test.tsx
@@ -1,0 +1,104 @@
+import { http, HttpResponse } from "msw"
+import { describe, expect, it } from "vitest"
+import { renderWithFileRoutes } from "@/test/renderers"
+import { server } from "@/test/setup"
+
+const consentsHandler = http.get("*/user/consents", () =>
+  HttpResponse.json({ current_policy_version: "test", consents: {} })
+)
+
+function makeAuthContext(overrides: {
+  email: string | null
+  tosAcceptedAt?: string | null
+}) {
+  return {
+    auth: {
+      isAuthenticated: true,
+      isLoading: false,
+      email: overrides.email,
+      userId: "u-1",
+      displayName: "ZeroEmpires",
+      avatarUrl: null,
+      tosAcceptedAt: overrides.tosAcceptedAt ?? null,
+      consents: null,
+      login: () => {},
+      logout: async () => {},
+      checkAuth: async () => {},
+      setConsents: () => {},
+    },
+  }
+}
+
+describe("root route email-required gate", () => {
+  it("redirects users with no email away from /profile to /accept-terms", async () => {
+    server.use(
+      http.get("*/auth/me", () =>
+        HttpResponse.json({
+          id: "u-1",
+          email: null,
+          display_name: "ZeroEmpires",
+          avatar_url: null,
+          tos_accepted_at: "2026-01-01T00:00:00Z",
+        })
+      ),
+      consentsHandler
+    )
+
+    const { router } = await renderWithFileRoutes(<></>, {
+      initialLocation: "/profile",
+      routerContext: makeAuthContext({
+        email: null,
+        tosAcceptedAt: "2026-01-01T00:00:00Z",
+      }),
+    })
+
+    expect(router.state.location.pathname).toBe("/accept-terms")
+  })
+
+  it("leaves /accept-terms reachable for users with no email", async () => {
+    server.use(
+      http.get("*/auth/me", () =>
+        HttpResponse.json({
+          id: "u-1",
+          email: null,
+          display_name: "ZeroEmpires",
+          avatar_url: null,
+          tos_accepted_at: null,
+        })
+      ),
+      consentsHandler
+    )
+
+    const { router } = await renderWithFileRoutes(<></>, {
+      initialLocation: "/accept-terms",
+      routerContext: makeAuthContext({ email: null }),
+    })
+
+    expect(router.state.location.pathname).toBe("/accept-terms")
+  })
+
+  it("does not redirect users with a real email", async () => {
+    server.use(
+      http.get("*/auth/me", () =>
+        HttpResponse.json({
+          id: "u-1",
+          email: "player@example.com",
+          display_name: null,
+          avatar_url: null,
+          tos_accepted_at: "2026-01-01T00:00:00Z",
+        })
+      ),
+      consentsHandler
+    )
+
+    const { router } = await renderWithFileRoutes(<></>, {
+      initialLocation: "/profile",
+      routerContext: makeAuthContext({
+        email: "player@example.com",
+        tosAcceptedAt: "2026-01-01T00:00:00Z",
+      }),
+    })
+
+    expect(router.state.location.pathname).toBe("/profile")
+  })
+})

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -51,9 +51,24 @@ interface RouterContext {
 // OAuth exchanges where interrupting the navigation would break sign-in.
 const CONSENT_REDIRECT_SKIP_PREFIXES = ["/profile", "/callback"]
 
+// Users without an email on file (Steam OAuth users pre-gate, per auth-api
+// #36) must finish setting one before using the rest of the app.
+// /accept-terms is the gate itself, /callback/* is the post-OAuth handoff
+// that already routes them there, and /login stays usable so they can sign
+// out without bouncing.
+const EMAIL_REQUIRED_SKIP_PREFIXES = ["/accept-terms", "/callback", "/login"]
+
 export const Route = createRootRouteWithContext<RouterContext>()({
   beforeLoad: ({ context, location }) => {
     if (!context.auth.isAuthenticated) return
+    if (
+      !context.auth.email &&
+      !EMAIL_REQUIRED_SKIP_PREFIXES.some((prefix) =>
+        location.pathname.startsWith(prefix)
+      )
+    ) {
+      throw redirect({ to: "/accept-terms" })
+    }
     const skip = CONSENT_REDIRECT_SKIP_PREFIXES.some((prefix) =>
       location.pathname.startsWith(prefix)
     )

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     TanStackRouterVite({
       target: "react",
       autoCodeSplitting: true,
+      routeFileIgnorePattern: "\\.test\\.(ts|tsx)$",
     }),
     react(),
     tailwindcss(),


### PR DESCRIPTION
## Summary
- Adds a root-route gate that redirects authenticated users with a null \`email\` to \`/accept-terms\` (skip prefixes: \`/accept-terms\`, \`/callback\`, \`/login\`). OAuth callback applies the same check so Steam users who previously accepted ToS get back through the gate on next login.
- Accept-terms page conditionally renders an email input when the signed-in user has no email on file. \"One more thing\" / backfill copy fires when ToS was already accepted, so the page doesn't read like a re-prompt.
- Handles the two structured 422 codes from the new accept-tos endpoint: \`email_required\` and \`email_already_registered\`. The latter shows an inline message + \"Sign in with that account instead\" CTA that logs the current user out and routes to /login.
- Fixes a latent bug in \`auth.tsx\` where a null email from \`/auth/me\` would be written to localStorage as the literal string \`\"null\"\`, which then hydrated back as a truthy string and silently bypassed the gate on reload.

Closes #36. Pairs with [ag-tech-group/criticalbit-auth-api#36](https://github.com/ag-tech-group/criticalbit-auth-api/issues/36) (already shipped) which made \`User.email\` nullable and dropped the synthetic placeholder pattern.

## Test plan
- [ ] Email/password signup flow still works (existing user with real email hits /accept-terms, checks the box, continues).
- [ ] Fresh Steam OAuth user lands on /accept-terms after callback; sees email input + ToS checkbox; submitting a valid email continues to /profile.
- [ ] Existing Steam user (already accepted old ToS, no email) on next login is routed back to /accept-terms; title says \"One more thing\"; checkbox hidden.
- [ ] Submit an email that already exists in another account → inline \"account with that email already exists\" + \"Sign in with that account instead\" button works (logs you out + routes to /login).
- [ ] Visit /profile directly as a no-email user → bounced to /accept-terms by the root gate.
- [ ] User with real email lands on /profile cleanly (no spurious redirect).