### PR TITLE
feat(verify-email): /verify-email page + verify-first OAuth merge guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ dist-ssr
 
 # TypeScript
 *.tsbuildinfo
+
+# Playwright MCP artifacts (screenshots, snapshot YAML, console logs)
+.playwright-mcp/

--- a/src/pages/callback/google-callback-page.test.tsx
+++ b/src/pages/callback/google-callback-page.test.tsx
@@ -1,0 +1,73 @@
+import { screen } from "@testing-library/react"
+import { http, HttpResponse } from "msw"
+import { describe, expect, it, vi } from "vitest"
+import { renderWithFileRoutes } from "@/test/renderers"
+import { server } from "@/test/setup"
+
+const unauthContext = {
+  auth: {
+    isAuthenticated: false,
+    isLoading: false,
+    email: null,
+    userId: null,
+    displayName: null,
+    avatarUrl: null,
+    tosAcceptedAt: null,
+    consents: null,
+    login: () => {},
+    logout: async () => {},
+    checkAuth: async () => {},
+    setConsents: () => {},
+  },
+}
+
+describe("GoogleCallbackPage error handling", () => {
+  it("surfaces verify-first guidance when the API refuses an unverified merge", async () => {
+    server.use(
+      http.get("*/auth/google/callback", () =>
+        HttpResponse.json(
+          { detail: "OAUTH_USER_ALREADY_EXISTS" },
+          { status: 400 }
+        )
+      )
+    )
+    vi.stubGlobal("location", {
+      ...window.location,
+      search: "?code=abc&state=xyz",
+    })
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/callback/google?code=abc&state=xyz",
+      routerContext: unauthContext,
+    })
+
+    expect(
+      await screen.findByText(/unverified account already exists/i)
+    ).toBeInTheDocument()
+
+    vi.unstubAllGlobals()
+  })
+
+  it("falls back to the generic message for other failures", async () => {
+    server.use(
+      http.get("*/auth/google/callback", () =>
+        HttpResponse.json({ detail: "OTHER_ERROR" }, { status: 400 })
+      )
+    )
+    vi.stubGlobal("location", {
+      ...window.location,
+      search: "?code=abc&state=xyz",
+    })
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/callback/google?code=abc&state=xyz",
+      routerContext: unauthContext,
+    })
+
+    expect(
+      await screen.findByText(/google sign-in failed/i)
+    ).toBeInTheDocument()
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/pages/callback/google-callback-page.tsx
+++ b/src/pages/callback/google-callback-page.tsx
@@ -1,6 +1,18 @@
 import { useEffect, useRef, useState } from "react"
 import { baseUrl } from "@/api/api"
 
+const OAUTH_USER_ALREADY_EXISTS_MESSAGE =
+  "An unverified account already exists for this email. Sign in with your password, verify your email, then link Google from your profile."
+
+async function readDetail(res: Response): Promise<string | null> {
+  try {
+    const body = await res.clone().json()
+    return typeof body?.detail === "string" ? body.detail : null
+  } catch {
+    return null
+  }
+}
+
 export function GoogleCallbackPage() {
   const [error, setError] = useState<string | null>(() => {
     const params = new URLSearchParams(window.location.search)
@@ -15,25 +27,36 @@ export function GoogleCallbackPage() {
     if (error || calledRef.current) return
     calledRef.current = true
 
-    fetch(`${baseUrl}/auth/google/callback${window.location.search}`, {
-      method: "GET",
-      credentials: "include",
+    async function completeSignIn() {
+      const res = await fetch(
+        `${baseUrl}/auth/google/callback${window.location.search}`,
+        { method: "GET", credentials: "include" }
+      )
+
+      if (!res.ok) {
+        const detail = await readDetail(res)
+        if (detail === "OAUTH_USER_ALREADY_EXISTS") {
+          setError(OAUTH_USER_ALREADY_EXISTS_MESSAGE)
+        } else {
+          setError("Google sign-in failed. Please try again.")
+        }
+        return
+      }
+
+      const savedRedirect = localStorage.getItem("auth_redirect")
+      localStorage.removeItem("auth_redirect")
+      window.location.href = savedRedirect ?? "/profile"
+    }
+
+    completeSignIn().catch(() => {
+      setError("Google sign-in failed. Please try again.")
     })
-      .then((res) => {
-        if (!res.ok) throw new Error(`Auth failed: ${res.status}`)
-        const savedRedirect = localStorage.getItem("auth_redirect")
-        localStorage.removeItem("auth_redirect")
-        window.location.href = savedRedirect ?? "/profile"
-      })
-      .catch(() => {
-        setError("Google sign-in failed. Please try again.")
-      })
   }, [error])
 
   if (error) {
     return (
-      <div className="flex flex-1 items-center justify-center">
-        <p className="text-destructive">{error}</p>
+      <div className="flex flex-1 items-center justify-center px-4">
+        <p className="text-destructive max-w-md text-center">{error}</p>
       </div>
     )
   }

--- a/src/pages/verify-email/verify-email-page.test.tsx
+++ b/src/pages/verify-email/verify-email-page.test.tsx
@@ -1,0 +1,118 @@
+import { screen } from "@testing-library/react"
+import { http, HttpResponse } from "msw"
+import { describe, expect, it } from "vitest"
+import { renderWithFileRoutes } from "@/test/renderers"
+import { server } from "@/test/setup"
+
+const unauthContext = {
+  auth: {
+    isAuthenticated: false,
+    isLoading: false,
+    email: null,
+    userId: null,
+    displayName: null,
+    avatarUrl: null,
+    tosAcceptedAt: null,
+    consents: null,
+    login: () => {},
+    logout: async () => {},
+    checkAuth: async () => {},
+    setConsents: () => {},
+  },
+}
+
+describe("VerifyEmailPage", () => {
+  it("shows the invalid-link card when no token is in the URL", async () => {
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/verify-email",
+      routerContext: unauthContext,
+    })
+    expect(
+      await screen.findByText("Invalid link", {
+        selector: "[data-slot='card-title']",
+      })
+    ).toBeInTheDocument()
+  })
+
+  it("posts the token to /auth/verify and shows the success card", async () => {
+    const captured: { body: unknown } = { body: null }
+    server.use(
+      http.post("*/auth/verify", async ({ request }) => {
+        captured.body = await request.json()
+        return HttpResponse.json({ id: "u-1", is_verified: true })
+      })
+    )
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/verify-email?token=good-token",
+      routerContext: unauthContext,
+    })
+
+    expect(
+      await screen.findByText("Email verified", {
+        selector: "[data-slot='card-title']",
+      })
+    ).toBeInTheDocument()
+    expect(captured.body).toEqual({ token: "good-token" })
+  })
+
+  it("treats VERIFY_USER_ALREADY_VERIFIED as success", async () => {
+    server.use(
+      http.post("*/auth/verify", () =>
+        HttpResponse.json(
+          { detail: "VERIFY_USER_ALREADY_VERIFIED" },
+          { status: 400 }
+        )
+      )
+    )
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/verify-email?token=already",
+      routerContext: unauthContext,
+    })
+
+    expect(
+      await screen.findByText("Email verified", {
+        selector: "[data-slot='card-title']",
+      })
+    ).toBeInTheDocument()
+  })
+
+  it("shows the invalid-link card on VERIFY_USER_BAD_TOKEN", async () => {
+    server.use(
+      http.post("*/auth/verify", () =>
+        HttpResponse.json({ detail: "VERIFY_USER_BAD_TOKEN" }, { status: 400 })
+      )
+    )
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/verify-email?token=expired",
+      routerContext: unauthContext,
+    })
+
+    expect(
+      await screen.findByText("Invalid link", {
+        selector: "[data-slot='card-title']",
+      })
+    ).toBeInTheDocument()
+  })
+
+  it("shows the generic failure card for unexpected errors", async () => {
+    server.use(
+      http.post("*/auth/verify", () =>
+        HttpResponse.json({ detail: "Something broke" }, { status: 500 })
+      )
+    )
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/verify-email?token=boom",
+      routerContext: unauthContext,
+    })
+
+    expect(
+      await screen.findByText("Verification failed", {
+        selector: "[data-slot='card-title']",
+      })
+    ).toBeInTheDocument()
+  })
+})

--- a/src/pages/verify-email/verify-email-page.tsx
+++ b/src/pages/verify-email/verify-email-page.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from "react"
+import { Link, useSearch } from "@tanstack/react-router"
+import { LoaderCircle } from "lucide-react"
+import {
+  Card,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { api } from "@/api/api"
+
+type Status = "pending" | "success" | "invalid" | "error"
+
+async function readDetail(error: unknown): Promise<string | null> {
+  const response = (error as { response?: Response })?.response
+  if (!response) return null
+  try {
+    const body = await response.clone().json()
+    return typeof body?.detail === "string" ? body.detail : null
+  } catch {
+    return null
+  }
+}
+
+export function VerifyEmailPage() {
+  const search = useSearch({ from: "/verify-email" })
+  const token = (search as { token?: string }).token
+
+  const [status, setStatus] = useState<Status>(token ? "pending" : "invalid")
+  const calledRef = useRef(false)
+
+  useEffect(() => {
+    if (!token || calledRef.current) return
+    calledRef.current = true
+
+    api
+      .post("auth/verify", { json: { token } })
+      .then(() => setStatus("success"))
+      .catch(async (error) => {
+        const detail = await readDetail(error)
+        // Treat already-verified as success — the user's intent (verified
+        // email) is satisfied, even if the token had already been spent.
+        if (detail === "VERIFY_USER_ALREADY_VERIFIED") {
+          setStatus("success")
+          return
+        }
+        setStatus(detail === "VERIFY_USER_BAD_TOKEN" ? "invalid" : "error")
+      })
+  }, [token])
+
+  if (status === "pending") {
+    return (
+      <div className="flex flex-1 items-center justify-center px-4">
+        <Card className="w-full max-w-sm">
+          <CardHeader className="text-center">
+            <CardTitle className="text-2xl">Verifying email</CardTitle>
+            <CardDescription className="flex items-center justify-center gap-2">
+              <LoaderCircle className="animate-spin" />
+              <span>Just a moment…</span>
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    )
+  }
+
+  if (status === "success") {
+    return (
+      <div className="flex flex-1 items-center justify-center px-4">
+        <Card className="w-full max-w-sm">
+          <CardHeader className="text-center">
+            <CardTitle className="text-2xl">Email verified</CardTitle>
+            <CardDescription>
+              Your email is verified. You can now sign in.
+            </CardDescription>
+          </CardHeader>
+          <CardFooter className="justify-center">
+            <Link to="/login" className="text-primary text-sm underline">
+              Sign in
+            </Link>
+          </CardFooter>
+        </Card>
+      </div>
+    )
+  }
+
+  if (status === "invalid") {
+    return (
+      <div className="flex flex-1 items-center justify-center px-4">
+        <Card className="w-full max-w-sm">
+          <CardHeader className="text-center">
+            <CardTitle className="text-2xl">Invalid link</CardTitle>
+            <CardDescription>
+              This verification link is invalid or has expired. Sign in and
+              request a new one from your profile.
+            </CardDescription>
+          </CardHeader>
+          <CardFooter className="justify-center">
+            <Link to="/login" className="text-primary text-sm underline">
+              Back to sign in
+            </Link>
+          </CardFooter>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-1 items-center justify-center px-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">Verification failed</CardTitle>
+          <CardDescription>
+            Something went wrong verifying your email. Please try again.
+          </CardDescription>
+        </CardHeader>
+        <CardFooter className="justify-center">
+          <Link to="/login" className="text-primary text-sm underline">
+            Back to sign in
+          </Link>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as VerifyEmailRouteImport } from './routes/verify-email'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as RegisterRouteImport } from './routes/register'
 import { Route as ProfileRouteImport } from './routes/profile'
@@ -21,6 +22,11 @@ import { Route as CallbackSteamRouteImport } from './routes/callback/steam'
 import { Route as CallbackGoogleCompleteRouteImport } from './routes/callback/google-complete'
 import { Route as CallbackGoogleRouteImport } from './routes/callback/google'
 
+const VerifyEmailRoute = VerifyEmailRouteImport.update({
+  id: '/verify-email',
+  path: '/verify-email',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ResetPasswordRoute = ResetPasswordRouteImport.update({
   id: '/reset-password',
   path: '/reset-password',
@@ -85,6 +91,7 @@ export interface FileRoutesByFullPath {
   '/profile': typeof ProfileRoute
   '/register': typeof RegisterRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/verify-email': typeof VerifyEmailRoute
   '/callback/google': typeof CallbackGoogleRoute
   '/callback/google-complete': typeof CallbackGoogleCompleteRoute
   '/callback/steam': typeof CallbackSteamRoute
@@ -98,6 +105,7 @@ export interface FileRoutesByTo {
   '/profile': typeof ProfileRoute
   '/register': typeof RegisterRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/verify-email': typeof VerifyEmailRoute
   '/callback/google': typeof CallbackGoogleRoute
   '/callback/google-complete': typeof CallbackGoogleCompleteRoute
   '/callback/steam': typeof CallbackSteamRoute
@@ -112,6 +120,7 @@ export interface FileRoutesById {
   '/profile': typeof ProfileRoute
   '/register': typeof RegisterRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/verify-email': typeof VerifyEmailRoute
   '/callback/google': typeof CallbackGoogleRoute
   '/callback/google-complete': typeof CallbackGoogleCompleteRoute
   '/callback/steam': typeof CallbackSteamRoute
@@ -127,6 +136,7 @@ export interface FileRouteTypes {
     | '/profile'
     | '/register'
     | '/reset-password'
+    | '/verify-email'
     | '/callback/google'
     | '/callback/google-complete'
     | '/callback/steam'
@@ -140,6 +150,7 @@ export interface FileRouteTypes {
     | '/profile'
     | '/register'
     | '/reset-password'
+    | '/verify-email'
     | '/callback/google'
     | '/callback/google-complete'
     | '/callback/steam'
@@ -153,6 +164,7 @@ export interface FileRouteTypes {
     | '/profile'
     | '/register'
     | '/reset-password'
+    | '/verify-email'
     | '/callback/google'
     | '/callback/google-complete'
     | '/callback/steam'
@@ -167,6 +179,7 @@ export interface RootRouteChildren {
   ProfileRoute: typeof ProfileRoute
   RegisterRoute: typeof RegisterRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
+  VerifyEmailRoute: typeof VerifyEmailRoute
   CallbackGoogleRoute: typeof CallbackGoogleRoute
   CallbackGoogleCompleteRoute: typeof CallbackGoogleCompleteRoute
   CallbackSteamRoute: typeof CallbackSteamRoute
@@ -175,6 +188,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/verify-email': {
+      id: '/verify-email'
+      path: '/verify-email'
+      fullPath: '/verify-email'
+      preLoaderRoute: typeof VerifyEmailRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/reset-password': {
       id: '/reset-password'
       path: '/reset-password'
@@ -263,6 +283,7 @@ const rootRouteChildren: RootRouteChildren = {
   ProfileRoute: ProfileRoute,
   RegisterRoute: RegisterRoute,
   ResetPasswordRoute: ResetPasswordRoute,
+  VerifyEmailRoute: VerifyEmailRoute,
   CallbackGoogleRoute: CallbackGoogleRoute,
   CallbackGoogleCompleteRoute: CallbackGoogleCompleteRoute,
   CallbackSteamRoute: CallbackSteamRoute,

--- a/src/routes/verify-email.tsx
+++ b/src/routes/verify-email.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { VerifyEmailPage } from "@/pages/verify-email/verify-email-page"
+
+type VerifyEmailSearch = {
+  token?: string
+}
+
+export const Route = createFileRoute("/verify-email")({
+  validateSearch: (search: Record<string, unknown>): VerifyEmailSearch => ({
+    token: (search.token as string) || undefined,
+  }),
+  component: VerifyEmailPage,
+})


### PR DESCRIPTION
## Summary

- New `/verify-email` route that POSTs `?token=...` to `/auth/verify` and renders success / invalid-link / generic-error cards. Treats `VERIFY_USER_ALREADY_VERIFIED` (400) as success so a second click (e.g. from another device) doesn't read as an error.
- The Google callback now maps the API's new `400 OAUTH_USER_ALREADY_EXISTS` detail to verify-first copy: _"An unverified account already exists for this email. Sign in with your password, verify your email, then link Google from your profile."_ This is the security-relevant piece — without it the takeover-vector mitigation just looks like a generic "Google sign-in failed".
- Adds `.playwright-mcp/` to `.gitignore` so MCP-driven browser sessions don't leak snapshot YAMLs/screenshots/console logs into the working tree.

## Why now

Pairs with [ag-tech-group/criticalbit-auth-api#39](https://github.com/ag-tech-group/criticalbit-auth-api/pull/39), which just merged. Registration now auto-dispatches a verification email pointing at `${FRONTEND_URL}/verify-email?token=<jwt>` — until this PR lands, every new registrant clicks a 404. Same PR introduced the OAuth merge refusal that this page's callback change explains to the user.

## Closes

- ag-tech-group/criticalbit-auth-web#11

## Test plan

### Unit (vitest, 7 new tests, 27 total — all passing)
- `verify-email-page.test.tsx` — no token, success, already-verified mapped to success, bad-token → invalid card, 500 → generic failure card.
- `google-callback-page.test.tsx` — `OAUTH_USER_ALREADY_EXISTS` → verify-first copy; other 400 detail → generic copy.

### Manual end-to-end (Playwright against real API + Postgres)
Drove the actual auth-api on a non-default port wired to a fresh Postgres:

| Scenario | Result | Network | DB |
|---|---|---|---|
| `/verify-email` (no token) | "Invalid link" | no call | — |
| `/verify-email?token=garbage` | "Invalid link" | POST /auth/verify → 400 | — |
| Register fake user → click verify URL from API logs | "Email verified" | POST /auth/verify → 200 | `is_verified=true` |
| Re-click same URL (already-verified) | "Email verified" | POST /auth/verify → 400 mapped to success | unchanged |

### Not covered end-to-end
- OAuth merge refusal path. Covered by the unit test in `google-callback-page.test.tsx`. A real Playwright run would need Google OAuth client creds plus a Google account whose email matches an unverified password user, which is more setup than the change warrants.

### Reviewer checklist
- [ ] `pnpm test:run`
- [ ] Click through `/verify-email` with no token / garbage token — both render "Invalid link".
- [ ] Register a new user against a local auth-api, grep `email.skipped` in API logs for the `verify_url`, click it — should land on "Email verified".