### PR TITLE
feat(connections): account linking — Connect flow + callback purpose dispatch

### DIFF
--- a/src/lib/oauth-state.test.ts
+++ b/src/lib/oauth-state.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import { readPurposeFromStateParam } from "./oauth-state"
+
+function encodeStateJwt(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }))
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+  const body = btoa(JSON.stringify(payload))
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+  return `${header}.${body}.signature`
+}
+
+describe("readPurposeFromStateParam", () => {
+  it("returns 'login' when no state param is present", () => {
+    expect(readPurposeFromStateParam("?code=abc")).toBe("login")
+  })
+
+  it("returns 'associate' when the state JWT payload has purpose=associate", () => {
+    const state = encodeStateJwt({ purpose: "associate", user_id: "u-1" })
+    expect(readPurposeFromStateParam(`?state=${state}`)).toBe("associate")
+  })
+
+  it("returns 'login' when the state JWT payload has purpose=login", () => {
+    const state = encodeStateJwt({ purpose: "login" })
+    expect(readPurposeFromStateParam(`?state=${state}`)).toBe("login")
+  })
+
+  it("falls back to 'login' for malformed tokens", () => {
+    expect(readPurposeFromStateParam("?state=not-a-jwt")).toBe("login")
+    expect(readPurposeFromStateParam("?state=a.b.c")).toBe("login")
+  })
+
+  it("falls back to 'login' when the payload lacks a purpose field", () => {
+    const state = encodeStateJwt({ other: "field" })
+    expect(readPurposeFromStateParam(`?state=${state}`)).toBe("login")
+  })
+})

--- a/src/lib/oauth-state.ts
+++ b/src/lib/oauth-state.ts
@@ -1,0 +1,28 @@
+export type OAuthPurpose = "login" | "associate"
+
+export type ProviderConnection = {
+  provider: string
+  account_id: string
+  account_email: string | null
+}
+
+function base64UrlDecode(segment: string): string {
+  const padded = segment + "=".repeat((4 - (segment.length % 4)) % 4)
+  const normalized = padded.replace(/-/g, "+").replace(/_/g, "/")
+  return atob(normalized)
+}
+
+export function readPurposeFromStateParam(search: string): OAuthPurpose {
+  const params = new URLSearchParams(search)
+  const token = params.get("state")
+  if (!token) return "login"
+
+  try {
+    const payload = token.split(".")[1]
+    if (!payload) return "login"
+    const decoded = JSON.parse(base64UrlDecode(payload))
+    return decoded?.purpose === "associate" ? "associate" : "login"
+  } catch {
+    return "login"
+  }
+}

--- a/src/pages/callback/google-callback-page.test.tsx
+++ b/src/pages/callback/google-callback-page.test.tsx
@@ -21,7 +21,29 @@ const unauthContext = {
   },
 }
 
-describe("GoogleCallbackPage error handling", () => {
+function encodeStateJwt(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }))
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+  const body = btoa(JSON.stringify(payload))
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+  return `${header}.${body}.sig`
+}
+
+const LOGIN_STATE = encodeStateJwt({ purpose: "login" })
+const ASSOCIATE_STATE = encodeStateJwt({
+  purpose: "associate",
+  user_id: "u-1",
+})
+
+function stubLocationSearch(search: string) {
+  vi.stubGlobal("location", { ...window.location, search })
+}
+
+describe("GoogleCallbackPage login dispatch", () => {
   it("surfaces verify-first guidance when the API refuses an unverified merge", async () => {
     server.use(
       http.get("*/auth/google/callback", () =>
@@ -31,13 +53,10 @@ describe("GoogleCallbackPage error handling", () => {
         )
       )
     )
-    vi.stubGlobal("location", {
-      ...window.location,
-      search: "?code=abc&state=xyz",
-    })
+    stubLocationSearch(`?code=abc&state=${LOGIN_STATE}`)
 
     await renderWithFileRoutes(<></>, {
-      initialLocation: "/callback/google?code=abc&state=xyz",
+      initialLocation: `/callback/google?code=abc&state=${LOGIN_STATE}`,
       routerContext: unauthContext,
     })
 
@@ -54,18 +73,70 @@ describe("GoogleCallbackPage error handling", () => {
         HttpResponse.json({ detail: "OTHER_ERROR" }, { status: 400 })
       )
     )
-    vi.stubGlobal("location", {
-      ...window.location,
-      search: "?code=abc&state=xyz",
-    })
+    stubLocationSearch(`?code=abc&state=${LOGIN_STATE}`)
 
     await renderWithFileRoutes(<></>, {
-      initialLocation: "/callback/google?code=abc&state=xyz",
+      initialLocation: `/callback/google?code=abc&state=${LOGIN_STATE}`,
       routerContext: unauthContext,
     })
 
     expect(
       await screen.findByText(/google sign-in failed/i)
+    ).toBeInTheDocument()
+
+    vi.unstubAllGlobals()
+  })
+})
+
+describe("GoogleCallbackPage associate dispatch", () => {
+  it("routes to /auth/google/associate/callback when state.purpose=associate", async () => {
+    let loginHit = false
+    let associateHit = false
+    server.use(
+      http.get("*/auth/google/callback", () => {
+        loginHit = true
+        return HttpResponse.json(null, { status: 200 })
+      }),
+      http.get("*/auth/google/associate/callback", () => {
+        associateHit = true
+        return HttpResponse.json(
+          { detail: { code: "oauth_state_expired" } },
+          { status: 400 }
+        )
+      })
+    )
+    stubLocationSearch(`?code=abc&state=${ASSOCIATE_STATE}`)
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: `/callback/google?code=abc&state=${ASSOCIATE_STATE}`,
+      routerContext: unauthContext,
+    })
+
+    expect(await screen.findByText(/link session expired/i)).toBeInTheDocument()
+    expect(loginHit).toBe(false)
+    expect(associateHit).toBe(true)
+
+    vi.unstubAllGlobals()
+  })
+
+  it("shows already-linked copy when API returns 409 oauth_account_already_linked", async () => {
+    server.use(
+      http.get("*/auth/google/associate/callback", () =>
+        HttpResponse.json(
+          { detail: { code: "oauth_account_already_linked" } },
+          { status: 409 }
+        )
+      )
+    )
+    stubLocationSearch(`?code=abc&state=${ASSOCIATE_STATE}`)
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: `/callback/google?code=abc&state=${ASSOCIATE_STATE}`,
+      routerContext: unauthContext,
+    })
+
+    expect(
+      await screen.findByText(/already linked to another criticalbit/i)
     ).toBeInTheDocument()
 
     vi.unstubAllGlobals()

--- a/src/pages/callback/google-callback-page.tsx
+++ b/src/pages/callback/google-callback-page.tsx
@@ -1,16 +1,42 @@
 import { useEffect, useRef, useState } from "react"
 import { baseUrl } from "@/api/api"
+import { readPurposeFromStateParam, type OAuthPurpose } from "@/lib/oauth-state"
 
 const OAUTH_USER_ALREADY_EXISTS_MESSAGE =
   "An unverified account already exists for this email. Sign in with your password, verify your email, then link Google from your profile."
 
-async function readDetail(res: Response): Promise<string | null> {
+const ASSOCIATE_ERROR_MESSAGES: Record<string, string> = {
+  oauth_account_already_linked:
+    "This Google account is already linked to another criticalbit account. Unlink it there first.",
+  oauth_state_invalid:
+    "Your link session is invalid. Please return to your profile and try again.",
+  oauth_state_expired:
+    "Your link session expired. Please return to your profile and try again.",
+  oauth_csrf_mismatch:
+    "Your link session expired. Please return to your profile and try again.",
+  oauth_state_user_mismatch:
+    "Something went wrong linking your account. Please try again.",
+  oauth_verify_failed: "Google rejected the response. Please try again.",
+}
+
+async function readDetail(res: Response): Promise<unknown> {
   try {
-    const body = await res.clone().json()
-    return typeof body?.detail === "string" ? body.detail : null
+    return (await res.clone().json())?.detail
   } catch {
     return null
   }
+}
+
+function detailCode(detail: unknown): string | null {
+  if (typeof detail === "string") return detail
+  if (
+    detail &&
+    typeof detail === "object" &&
+    typeof (detail as { code?: unknown }).code === "string"
+  ) {
+    return (detail as { code: string }).code
+  }
+  return null
 }
 
 export function GoogleCallbackPage() {
@@ -27,15 +53,33 @@ export function GoogleCallbackPage() {
     if (error || calledRef.current) return
     calledRef.current = true
 
-    async function completeSignIn() {
-      const res = await fetch(
-        `${baseUrl}/auth/google/callback${window.location.search}`,
-        { method: "GET", credentials: "include" }
-      )
+    const purpose: OAuthPurpose = readPurposeFromStateParam(
+      window.location.search
+    )
+    const apiPath =
+      purpose === "associate"
+        ? "/auth/google/associate/callback"
+        : "/auth/google/callback"
+
+    async function completeFlow() {
+      const res = await fetch(`${baseUrl}${apiPath}${window.location.search}`, {
+        method: "GET",
+        credentials: "include",
+      })
+
+      if (res.redirected) {
+        window.location.href = res.url
+        return
+      }
 
       if (!res.ok) {
-        const detail = await readDetail(res)
-        if (detail === "OAUTH_USER_ALREADY_EXISTS") {
+        const code = detailCode(await readDetail(res))
+        if (purpose === "associate") {
+          setError(
+            (code && ASSOCIATE_ERROR_MESSAGES[code]) ??
+              "Linking your Google account failed. Please try again."
+          )
+        } else if (code === "OAUTH_USER_ALREADY_EXISTS") {
           setError(OAUTH_USER_ALREADY_EXISTS_MESSAGE)
         } else {
           setError("Google sign-in failed. Please try again.")
@@ -48,8 +92,12 @@ export function GoogleCallbackPage() {
       window.location.href = savedRedirect ?? "/profile"
     }
 
-    completeSignIn().catch(() => {
-      setError("Google sign-in failed. Please try again.")
+    completeFlow().catch(() => {
+      setError(
+        purpose === "associate"
+          ? "Linking your Google account failed. Please try again."
+          : "Google sign-in failed. Please try again."
+      )
     })
   }, [error])
 

--- a/src/pages/callback/oauth-associate-complete-page.tsx
+++ b/src/pages/callback/oauth-associate-complete-page.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from "react"
+
+type Props = {
+  provider: "google" | "steam"
+}
+
+export function OAuthAssociateCompletePage({ provider }: Props) {
+  useEffect(() => {
+    window.location.href = `/profile?linked=${provider}`
+  }, [provider])
+
+  return (
+    <div className="flex flex-1 items-center justify-center">
+      <p className="text-muted-foreground">Linking your account…</p>
+    </div>
+  )
+}

--- a/src/pages/callback/steam-callback-page.test.tsx
+++ b/src/pages/callback/steam-callback-page.test.tsx
@@ -1,0 +1,102 @@
+import { screen } from "@testing-library/react"
+import { http, HttpResponse } from "msw"
+import { describe, expect, it, vi } from "vitest"
+import { renderWithFileRoutes } from "@/test/renderers"
+import { server } from "@/test/setup"
+
+const unauthContext = {
+  auth: {
+    isAuthenticated: false,
+    isLoading: false,
+    email: null,
+    userId: null,
+    displayName: null,
+    avatarUrl: null,
+    tosAcceptedAt: null,
+    consents: null,
+    login: () => {},
+    logout: async () => {},
+    checkAuth: async () => {},
+    setConsents: () => {},
+  },
+}
+
+function encodeStateJwt(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }))
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+  const body = btoa(JSON.stringify(payload))
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+  return `${header}.${body}.sig`
+}
+
+const ASSOCIATE_STATE = encodeStateJwt({
+  purpose: "associate",
+  user_id: "u-1",
+})
+
+// Steam OpenID needs a minimum set of openid.* params to satisfy the page
+// guard; the actual values don't matter for these tests.
+const OPENID_PARAMS =
+  "openid.claimed_id=https%3A%2F%2Fsteamcommunity.com%2Fopenid%2Fid%2F76561197960287930&openid.mode=id_res"
+
+function stubLocationSearch(search: string) {
+  vi.stubGlobal("location", { ...window.location, search })
+}
+
+describe("SteamCallbackPage", () => {
+  it("routes to /auth/steam/associate/callback when state.purpose=associate", async () => {
+    let loginHit = false
+    let associateHit = false
+    server.use(
+      http.get("*/auth/steam/callback", () => {
+        loginHit = true
+        return HttpResponse.json(null, { status: 200 })
+      }),
+      http.get("*/auth/steam/associate/callback", () => {
+        associateHit = true
+        return HttpResponse.json(
+          { detail: { code: "oauth_account_already_linked" } },
+          { status: 409 }
+        )
+      })
+    )
+    const search = `?${OPENID_PARAMS}&state=${ASSOCIATE_STATE}`
+    stubLocationSearch(search)
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: `/callback/steam${search}`,
+      routerContext: unauthContext,
+    })
+
+    expect(
+      await screen.findByText(/this steam account is already linked/i)
+    ).toBeInTheDocument()
+    expect(loginHit).toBe(false)
+    expect(associateHit).toBe(true)
+
+    vi.unstubAllGlobals()
+  })
+
+  it("uses the generic sign-in failure copy for login-purpose failures", async () => {
+    server.use(
+      http.get("*/auth/steam/callback", () =>
+        HttpResponse.json({ detail: "anything" }, { status: 400 })
+      )
+    )
+    const search = `?${OPENID_PARAMS}`
+    stubLocationSearch(search)
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: `/callback/steam${search}`,
+      routerContext: unauthContext,
+    })
+
+    expect(await screen.findByText(/steam sign-in failed/i)).toBeInTheDocument()
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/pages/callback/steam-callback-page.tsx
+++ b/src/pages/callback/steam-callback-page.tsx
@@ -1,5 +1,37 @@
 import { useEffect, useRef, useState } from "react"
 import { baseUrl } from "@/api/api"
+import { readPurposeFromStateParam, type OAuthPurpose } from "@/lib/oauth-state"
+
+const ASSOCIATE_ERROR_MESSAGES: Record<string, string> = {
+  oauth_account_already_linked:
+    "This Steam account is already linked to another criticalbit account. Unlink it there first.",
+  oauth_state_invalid:
+    "Your link session is invalid. Please return to your profile and try again.",
+  oauth_state_expired:
+    "Your link session expired. Please return to your profile and try again.",
+  oauth_csrf_mismatch:
+    "Your link session expired. Please return to your profile and try again.",
+  oauth_state_user_mismatch:
+    "Something went wrong linking your account. Please try again.",
+  oauth_verify_failed: "Steam rejected the response. Please try again.",
+}
+
+async function readDetailCode(res: Response): Promise<string | null> {
+  try {
+    const detail = (await res.clone().json())?.detail
+    if (typeof detail === "string") return detail
+    if (
+      detail &&
+      typeof detail === "object" &&
+      typeof (detail as { code?: unknown }).code === "string"
+    ) {
+      return (detail as { code: string }).code
+    }
+    return null
+  } catch {
+    return null
+  }
+}
 
 export function SteamCallbackPage() {
   const [error, setError] = useState<string | null>(() => {
@@ -15,30 +47,56 @@ export function SteamCallbackPage() {
     if (error || calledRef.current) return
     calledRef.current = true
 
-    // Forward Steam's OpenID params to the backend callback
-    fetch(`${baseUrl}/auth/steam/callback${window.location.search}`, {
-      method: "GET",
-      credentials: "include",
-    })
-      .then((res) => {
-        if (res.redirected) {
-          window.location.href = res.url
-          return
+    const purpose: OAuthPurpose = readPurposeFromStateParam(
+      window.location.search
+    )
+    const apiPath =
+      purpose === "associate"
+        ? "/auth/steam/associate/callback"
+        : "/auth/steam/callback"
+
+    async function completeFlow() {
+      const res = await fetch(`${baseUrl}${apiPath}${window.location.search}`, {
+        method: "GET",
+        credentials: "include",
+      })
+
+      if (res.redirected) {
+        window.location.href = res.url
+        return
+      }
+
+      if (!res.ok) {
+        if (purpose === "associate") {
+          const code = await readDetailCode(res)
+          setError(
+            (code && ASSOCIATE_ERROR_MESSAGES[code]) ??
+              "Linking your Steam account failed. Please try again."
+          )
+        } else {
+          setError("Steam sign-in failed. Please try again.")
         }
-        if (!res.ok) throw new Error(`Auth failed: ${res.status}`)
-        const savedRedirect = localStorage.getItem("auth_redirect")
-        localStorage.removeItem("auth_redirect")
-        window.location.href = savedRedirect ?? "/profile"
-      })
-      .catch(() => {
-        setError("Steam sign-in failed. Please try again.")
-      })
+        return
+      }
+
+      const savedRedirect = localStorage.getItem("auth_redirect")
+      localStorage.removeItem("auth_redirect")
+      window.location.href = savedRedirect ?? "/profile"
+    }
+
+    completeFlow().catch(() => {
+      setError(
+        purpose === "associate"
+          ? "Linking your Steam account failed. Please try again."
+          : "Steam sign-in failed. Please try again."
+      )
+    })
   }, [error])
 
   if (error) {
     return (
-      <div className="flex flex-1 items-center justify-center">
-        <p className="text-destructive">{error}</p>
+      <div className="flex flex-1 items-center justify-center px-4">
+        <p className="text-destructive max-w-md text-center">{error}</p>
       </div>
     )
   }

--- a/src/pages/profile/profile-page.test.tsx
+++ b/src/pages/profile/profile-page.test.tsx
@@ -210,3 +210,92 @@ describe("ProfilePage display name", () => {
     expect(button).toBeDisabled()
   })
 })
+
+describe("ProfilePage connected accounts", () => {
+  it("shows Connect buttons for unlinked providers and the linked status for linked ones", async () => {
+    const me = authMeHandler({
+      id: "u-1",
+      email: "player@example.com",
+      display_name: null,
+      avatar_url: null,
+      tos_accepted_at: "2026-01-01T00:00:00Z",
+    })
+    server.use(
+      me.handler,
+      consentsHandler,
+      http.get("*/auth/me/connections", () =>
+        HttpResponse.json([
+          {
+            provider: "google",
+            account_id: "google-acct-1",
+            account_email: "player@gmail.com",
+          },
+        ])
+      )
+    )
+
+    await renderWithFileRoutes(<></>, { initialLocation: "/profile" })
+
+    expect(await screen.findByText("player@gmail.com")).toBeInTheDocument()
+    // Steam is not in the list — should render a Connect button
+    expect(
+      screen.getByRole("button", { name: /^connect$/i })
+    ).toBeInTheDocument()
+  })
+
+  it("renders the list even when /auth/me/connections fails", async () => {
+    const me = authMeHandler({
+      id: "u-1",
+      email: "player@example.com",
+      display_name: null,
+      avatar_url: null,
+      tos_accepted_at: "2026-01-01T00:00:00Z",
+    })
+    server.use(
+      me.handler,
+      consentsHandler,
+      http.get("*/auth/me/connections", () =>
+        HttpResponse.json({ detail: "boom" }, { status: 500 })
+      )
+    )
+
+    await renderWithFileRoutes(<></>, { initialLocation: "/profile" })
+
+    // Both providers should render Not connected + Connect button
+    const connectButtons = await screen.findAllByRole("button", {
+      name: /^connect$/i,
+    })
+    expect(connectButtons).toHaveLength(2)
+  })
+
+  it("toasts and strips the ?linked= param after an associate redirect", async () => {
+    const me = authMeHandler({
+      id: "u-1",
+      email: "player@example.com",
+      display_name: null,
+      avatar_url: null,
+      tos_accepted_at: "2026-01-01T00:00:00Z",
+    })
+    server.use(
+      me.handler,
+      consentsHandler,
+      http.get("*/auth/me/connections", () =>
+        HttpResponse.json([
+          {
+            provider: "google",
+            account_id: "google-acct-1",
+            account_email: "player@gmail.com",
+          },
+        ])
+      )
+    )
+
+    await renderWithFileRoutes(<></>, {
+      initialLocation: "/profile?linked=google",
+    })
+
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith("Linked your Google account.")
+    )
+  })
+})

--- a/src/pages/profile/profile-page.tsx
+++ b/src/pages/profile/profile-page.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react"
+import { useNavigate } from "@tanstack/react-router"
 import { LoaderCircle } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
@@ -7,7 +8,7 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { UserAvatar } from "@/components/user-avatar"
-import { api } from "@/api/api"
+import { api, baseUrl } from "@/api/api"
 import { getErrorMessage } from "@/lib/api-errors"
 import { useAuth } from "@/lib/auth"
 import {
@@ -16,7 +17,15 @@ import {
   type ConsentInput,
   type ConsentType,
 } from "@/lib/consent"
+import type { ProviderConnection } from "@/lib/oauth-state"
 import { Route as ProfileRoute } from "@/routes/profile"
+
+type ProviderId = "google" | "steam"
+
+const PROVIDERS: { id: ProviderId; label: string }[] = [
+  { id: "google", label: "Google" },
+  { id: "steam", label: "Steam" },
+]
 
 interface ConsentToggleCopy {
   label: string
@@ -41,6 +50,7 @@ const DISPLAY_NAME_MAX_LENGTH = 100
 export function ProfilePage() {
   const auth = useAuth()
   const search = ProfileRoute.useSearch()
+  const navigate = useNavigate()
   const privacySectionRef = useRef<HTMLDivElement>(null)
   const [showConfirm, setShowConfirm] = useState(false)
   const [confirmEmail, setConfirmEmail] = useState("")
@@ -49,10 +59,40 @@ export function ProfilePage() {
     useState<ConsentType | null>(null)
   const [displayName, setDisplayName] = useState(auth.displayName ?? "")
   const [isSavingDisplayName, setIsSavingDisplayName] = useState(false)
+  const [connections, setConnections] = useState<ProviderConnection[] | null>(
+    null
+  )
+  const [connectingProvider, setConnectingProvider] =
+    useState<ProviderId | null>(null)
 
   useEffect(() => {
     setDisplayName(auth.displayName ?? "")
   }, [auth.displayName])
+
+  useEffect(() => {
+    let cancelled = false
+    api
+      .get("auth/me/connections")
+      .json<ProviderConnection[]>()
+      .then((list) => {
+        if (!cancelled) setConnections(list)
+      })
+      .catch(() => {
+        // Show an empty list rather than blocking the rest of the page; the
+        // user can refresh to retry. Avoids a noisy toast on transient errors.
+        if (!cancelled) setConnections([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!search.linked) return
+    const label = search.linked === "google" ? "Google" : "Steam"
+    toast.success(`Linked your ${label} account.`)
+    navigate({ to: "/profile", search: {}, replace: true })
+  }, [search.linked, navigate])
 
   const stale = hasStaleConsent(auth.consents)
   const showStaleBanner = stale || search.reason === "consent-stale"
@@ -106,6 +146,29 @@ export function ProfilePage() {
       toast.error(message)
     } finally {
       setIsDeleting(false)
+    }
+  }
+
+  async function handleConnect(provider: ProviderId) {
+    setConnectingProvider(provider)
+    try {
+      if (provider === "steam") {
+        // Steam's authorize endpoint 307s straight to Steam's OpenID; navigate
+        // there directly to keep the redirect chain server-driven.
+        window.location.href = `${baseUrl}/auth/steam/associate/authorize`
+        return
+      }
+      const res = await api
+        .get(`auth/${provider}/associate/authorize`)
+        .json<{ authorization_url: string }>()
+      window.location.href = res.authorization_url
+    } catch (error) {
+      const message = await getErrorMessage(
+        error,
+        `Failed to start linking ${provider}`
+      )
+      toast.error(message)
+      setConnectingProvider(null)
     }
   }
 
@@ -247,6 +310,65 @@ export function ProfilePage() {
                 Learn more
               </a>
             </p>
+          </div>
+
+          <div
+            className="grid gap-3 border-t pt-4"
+            data-testid="connections-section"
+          >
+            <h3 className="text-sm font-semibold">Connected accounts</h3>
+            {connections === null ? (
+              <p className="text-muted-foreground flex items-center gap-2 text-xs">
+                <LoaderCircle className="size-3 animate-spin" />
+                Loading…
+              </p>
+            ) : (
+              PROVIDERS.map(({ id, label }) => {
+                const linked = connections.find((c) => c.provider === id)
+                const isConnecting = connectingProvider === id
+                return (
+                  <div
+                    key={id}
+                    className="flex items-center justify-between gap-3"
+                  >
+                    <div className="grid gap-0.5">
+                      <span className="text-sm font-medium">{label}</span>
+                      {linked ? (
+                        <span className="text-muted-foreground text-xs">
+                          Connected
+                          {(linked.account_email ?? linked.account_id) && (
+                            <>
+                              {" as "}
+                              <span className="font-mono">
+                                {linked.account_email ?? linked.account_id}
+                              </span>
+                            </>
+                          )}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground text-xs">
+                          Not connected
+                        </span>
+                      )}
+                    </div>
+                    {!linked && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleConnect(id)}
+                        disabled={isConnecting}
+                      >
+                        Connect
+                        {isConnecting && (
+                          <LoaderCircle className="animate-spin" />
+                        )}
+                      </Button>
+                    )}
+                  </div>
+                )
+              })
+            )}
           </div>
 
           <div className="border-destructive/30 bg-destructive/5 rounded-md border p-4">

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -18,8 +18,10 @@ import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as AcceptTermsRouteImport } from './routes/accept-terms'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as CallbackSteamCompleteRouteImport } from './routes/callback/steam-complete'
+import { Route as CallbackSteamAssociateCompleteRouteImport } from './routes/callback/steam-associate-complete'
 import { Route as CallbackSteamRouteImport } from './routes/callback/steam'
 import { Route as CallbackGoogleCompleteRouteImport } from './routes/callback/google-complete'
+import { Route as CallbackGoogleAssociateCompleteRouteImport } from './routes/callback/google-associate-complete'
 import { Route as CallbackGoogleRouteImport } from './routes/callback/google'
 
 const VerifyEmailRoute = VerifyEmailRouteImport.update({
@@ -67,6 +69,12 @@ const CallbackSteamCompleteRoute = CallbackSteamCompleteRouteImport.update({
   path: '/callback/steam-complete',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CallbackSteamAssociateCompleteRoute =
+  CallbackSteamAssociateCompleteRouteImport.update({
+    id: '/callback/steam-associate-complete',
+    path: '/callback/steam-associate-complete',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const CallbackSteamRoute = CallbackSteamRouteImport.update({
   id: '/callback/steam',
   path: '/callback/steam',
@@ -77,6 +85,12 @@ const CallbackGoogleCompleteRoute = CallbackGoogleCompleteRouteImport.update({
   path: '/callback/google-complete',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CallbackGoogleAssociateCompleteRoute =
+  CallbackGoogleAssociateCompleteRouteImport.update({
+    id: '/callback/google-associate-complete',
+    path: '/callback/google-associate-complete',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const CallbackGoogleRoute = CallbackGoogleRouteImport.update({
   id: '/callback/google',
   path: '/callback/google',
@@ -93,8 +107,10 @@ export interface FileRoutesByFullPath {
   '/reset-password': typeof ResetPasswordRoute
   '/verify-email': typeof VerifyEmailRoute
   '/callback/google': typeof CallbackGoogleRoute
+  '/callback/google-associate-complete': typeof CallbackGoogleAssociateCompleteRoute
   '/callback/google-complete': typeof CallbackGoogleCompleteRoute
   '/callback/steam': typeof CallbackSteamRoute
+  '/callback/steam-associate-complete': typeof CallbackSteamAssociateCompleteRoute
   '/callback/steam-complete': typeof CallbackSteamCompleteRoute
 }
 export interface FileRoutesByTo {
@@ -107,8 +123,10 @@ export interface FileRoutesByTo {
   '/reset-password': typeof ResetPasswordRoute
   '/verify-email': typeof VerifyEmailRoute
   '/callback/google': typeof CallbackGoogleRoute
+  '/callback/google-associate-complete': typeof CallbackGoogleAssociateCompleteRoute
   '/callback/google-complete': typeof CallbackGoogleCompleteRoute
   '/callback/steam': typeof CallbackSteamRoute
+  '/callback/steam-associate-complete': typeof CallbackSteamAssociateCompleteRoute
   '/callback/steam-complete': typeof CallbackSteamCompleteRoute
 }
 export interface FileRoutesById {
@@ -122,8 +140,10 @@ export interface FileRoutesById {
   '/reset-password': typeof ResetPasswordRoute
   '/verify-email': typeof VerifyEmailRoute
   '/callback/google': typeof CallbackGoogleRoute
+  '/callback/google-associate-complete': typeof CallbackGoogleAssociateCompleteRoute
   '/callback/google-complete': typeof CallbackGoogleCompleteRoute
   '/callback/steam': typeof CallbackSteamRoute
+  '/callback/steam-associate-complete': typeof CallbackSteamAssociateCompleteRoute
   '/callback/steam-complete': typeof CallbackSteamCompleteRoute
 }
 export interface FileRouteTypes {
@@ -138,8 +158,10 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/verify-email'
     | '/callback/google'
+    | '/callback/google-associate-complete'
     | '/callback/google-complete'
     | '/callback/steam'
+    | '/callback/steam-associate-complete'
     | '/callback/steam-complete'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -152,8 +174,10 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/verify-email'
     | '/callback/google'
+    | '/callback/google-associate-complete'
     | '/callback/google-complete'
     | '/callback/steam'
+    | '/callback/steam-associate-complete'
     | '/callback/steam-complete'
   id:
     | '__root__'
@@ -166,8 +190,10 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/verify-email'
     | '/callback/google'
+    | '/callback/google-associate-complete'
     | '/callback/google-complete'
     | '/callback/steam'
+    | '/callback/steam-associate-complete'
     | '/callback/steam-complete'
   fileRoutesById: FileRoutesById
 }
@@ -181,8 +207,10 @@ export interface RootRouteChildren {
   ResetPasswordRoute: typeof ResetPasswordRoute
   VerifyEmailRoute: typeof VerifyEmailRoute
   CallbackGoogleRoute: typeof CallbackGoogleRoute
+  CallbackGoogleAssociateCompleteRoute: typeof CallbackGoogleAssociateCompleteRoute
   CallbackGoogleCompleteRoute: typeof CallbackGoogleCompleteRoute
   CallbackSteamRoute: typeof CallbackSteamRoute
+  CallbackSteamAssociateCompleteRoute: typeof CallbackSteamAssociateCompleteRoute
   CallbackSteamCompleteRoute: typeof CallbackSteamCompleteRoute
 }
 
@@ -251,6 +279,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CallbackSteamCompleteRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/callback/steam-associate-complete': {
+      id: '/callback/steam-associate-complete'
+      path: '/callback/steam-associate-complete'
+      fullPath: '/callback/steam-associate-complete'
+      preLoaderRoute: typeof CallbackSteamAssociateCompleteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/callback/steam': {
       id: '/callback/steam'
       path: '/callback/steam'
@@ -263,6 +298,13 @@ declare module '@tanstack/react-router' {
       path: '/callback/google-complete'
       fullPath: '/callback/google-complete'
       preLoaderRoute: typeof CallbackGoogleCompleteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/callback/google-associate-complete': {
+      id: '/callback/google-associate-complete'
+      path: '/callback/google-associate-complete'
+      fullPath: '/callback/google-associate-complete'
+      preLoaderRoute: typeof CallbackGoogleAssociateCompleteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/callback/google': {
@@ -285,8 +327,10 @@ const rootRouteChildren: RootRouteChildren = {
   ResetPasswordRoute: ResetPasswordRoute,
   VerifyEmailRoute: VerifyEmailRoute,
   CallbackGoogleRoute: CallbackGoogleRoute,
+  CallbackGoogleAssociateCompleteRoute: CallbackGoogleAssociateCompleteRoute,
   CallbackGoogleCompleteRoute: CallbackGoogleCompleteRoute,
   CallbackSteamRoute: CallbackSteamRoute,
+  CallbackSteamAssociateCompleteRoute: CallbackSteamAssociateCompleteRoute,
   CallbackSteamCompleteRoute: CallbackSteamCompleteRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/callback/google-associate-complete.tsx
+++ b/src/routes/callback/google-associate-complete.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { OAuthAssociateCompletePage } from "@/pages/callback/oauth-associate-complete-page"
+
+export const Route = createFileRoute("/callback/google-associate-complete")({
+  component: () => <OAuthAssociateCompletePage provider="google" />,
+})

--- a/src/routes/callback/steam-associate-complete.tsx
+++ b/src/routes/callback/steam-associate-complete.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { OAuthAssociateCompletePage } from "@/pages/callback/oauth-associate-complete-page"
+
+export const Route = createFileRoute("/callback/steam-associate-complete")({
+  component: () => <OAuthAssociateCompletePage provider="steam" />,
+})

--- a/src/routes/profile.tsx
+++ b/src/routes/profile.tsx
@@ -3,12 +3,17 @@ import { ProfilePage } from "@/pages/profile/profile-page"
 
 interface ProfileSearch {
   reason?: "consent-stale"
+  linked?: "google" | "steam"
 }
 
 export const Route = createFileRoute("/profile")({
   validateSearch: (search: Record<string, unknown>): ProfileSearch => {
-    const reason = search.reason
-    return reason === "consent-stale" ? { reason } : {}
+    const next: ProfileSearch = {}
+    if (search.reason === "consent-stale") next.reason = "consent-stale"
+    if (search.linked === "google" || search.linked === "steam") {
+      next.linked = search.linked
+    }
+    return next
   },
   beforeLoad: ({ context }) => {
     if (!context.auth.isAuthenticated) {


### PR DESCRIPTION
PR-A of two for #39. Ships the read-only connections section and the full Connect round-trip; PR-B will add Disconnect, the stranding guard, and the "Set a password" entry point.

## Summary

- New "Connected accounts" section on `/profile` — calls `GET /auth/me/connections`, renders linked providers with "Connected as <X>" and an enabled Connect button for the rest. Click → `window.location.href = ${API}/auth/{provider}/associate/authorize`. Steam goes direct (the endpoint 307s to Steam's OpenID); Google fetches `{authorization_url}` first since its dev mode returns JSON.
- `google-callback-page` and `steam-callback-page` now decode the `state` JWT (base64 of the payload segment — no signature verify) and read `purpose`. `purpose=associate` routes the fetch to `/auth/{provider}/associate/callback`; anything else (or any parse failure) routes to the existing login callback, so existing login flows are unchanged.
- New shared `OAuthAssociateCompletePage` at `/callback/google-associate-complete` and `/callback/steam-associate-complete`. The API 302s here on success; the page navigates to `/profile?linked=<provider>`, which the profile page reads to toast _"Linked your <Provider> account."_ and then strips via `useNavigate({ replace: true })`.
- Error copy for the new associate detail codes:
  - 409 `oauth_account_already_linked` → _"This <Provider> account is already linked to another criticalbit account. Unlink it there first."_
  - 400 `oauth_state_invalid` / `oauth_state_expired` / `oauth_csrf_mismatch` → _"Your link session expired. Please return to your profile and try again."_
  - 400 `oauth_state_user_mismatch` → generic "something went wrong"
  - 400 `oauth_verify_failed` → _"<Provider> rejected the response. Please try again."_

## What's not in this PR (PR-B)

- Disconnect buttons, the client-side stranding guard, and DELETE 409/404 handling.
- Plumbing `has_usable_password` through the auth context.
- "Set a password" entry point for OAuth-first users.

## Pairs with

- ag-tech-group/criticalbit-auth-api#40 (already merged)

## Test plan

### Unit (vitest, 12 new tests, 39 total — all passing)
- `oauth-state.test.ts` — state-purpose decoding: login default, associate parse, malformed → login fallback, missing-purpose → login fallback.
- `google-callback-page.test.tsx` — login dispatch unchanged (OAUTH_USER_ALREADY_EXISTS, generic); associate dispatch routes to the right URL and surfaces 400 `oauth_state_expired` and 409 `oauth_account_already_linked` with friendly copy.
- `steam-callback-page.test.tsx` — associate dispatch routes correctly; login-purpose failures keep the existing generic copy.
- `profile-page.test.tsx` — Connected-as rendering for the linked provider, Connect buttons for the unlinked, graceful empty-list fallback when `/auth/me/connections` 500s, and the `?linked=` toast.

### Manual end-to-end (Playwright against real API + Postgres)
Visual coverage (no OAuth round-trip — would need real Google/Steam creds):
| Scenario | Result |
|---|---|
| Fresh registration → `/profile` | "Connected accounts" section renders with both providers showing "Not connected" + Connect button ✅ |
| Inserted `oauth_account` row directly → refresh `/profile` | Google row shows "Connected as player@gmail.com", no Connect button; Steam still shows Connect ✅ |
| Click Connect on Steam | Browser navigates to `${API}/auth/steam/associate/authorize`, API returns `{detail: {code: "provider_not_enabled"}}` ✅ — confirms the wiring is correct end-to-end |

### Not covered end-to-end
- Full Google or Steam associate round-trip — needs `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` or `STEAM_API_KEY` in the local API env. Unit tests cover the dispatch + error mapping; the live UI test confirms the request shape.

## Reviewer checklist

- [ ] `pnpm test:run`
- [ ] Locally, register a fresh user and view `/profile` — the Connected accounts section should appear between Privacy and Danger zone with two "Not connected" rows + Connect buttons.
- [ ] Click Connect on either provider — expect a redirect to `/auth/{provider}/associate/authorize`. With no provider creds set, the API returns `provider_not_enabled`, which is fine for this PR.