### PR TITLE
feat(connections): disconnect, stranding guard, and Set-a-password CTA

### DIFF
--- a/src/components/navbar.test.tsx
+++ b/src/components/navbar.test.tsx
@@ -24,6 +24,7 @@ const unauthContext = {
     displayName: null,
     avatarUrl: null,
     tosAcceptedAt: null,
+    hasUsablePassword: false,
     consents: null,
     login: () => {},
     logout: async () => {},

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -26,6 +26,7 @@ interface AuthContextValue {
   displayName: string | null
   avatarUrl: string | null
   tosAcceptedAt: string | null
+  hasUsablePassword: boolean
   consents: ConsentsResponse | null
   login: (email: string) => void
   logout: () => Promise<void>
@@ -46,6 +47,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [displayName, setDisplayName] = useState<string | null>(null)
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null)
   const [tosAcceptedAt, setTosAcceptedAt] = useState<string | null>(null)
+  const [hasUsablePassword, setHasUsablePassword] = useState(false)
   const [consents, setConsentsState] = useState<ConsentsResponse | null>(null)
 
   const setConsents = useCallback((next: ConsentsResponse) => {
@@ -61,6 +63,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setDisplayName(null)
     setTosAcceptedAt(null)
     setAvatarUrl(null)
+    setHasUsablePassword(false)
     setConsentsState(null)
     clearCachedConsents()
     resetAnalytics()
@@ -90,6 +93,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         display_name: string | null
         avatar_url: string | null
         tos_accepted_at: string | null
+        has_usable_password?: boolean
       }>()
       setIsAuthenticated(true)
       setEmail(user.email)
@@ -97,6 +101,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setDisplayName(user.display_name)
       setAvatarUrl(user.avatar_url)
       setTosAcceptedAt(user.tos_accepted_at)
+      setHasUsablePassword(user.has_usable_password ?? false)
       // Steam OAuth users start with no email until they pass /accept-terms;
       // don't cache "null" as a string and don't leave a stale value behind.
       if (user.email) {
@@ -140,6 +145,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       displayName,
       avatarUrl,
       tosAcceptedAt,
+      hasUsablePassword,
       consents,
       login,
       logout,
@@ -154,6 +160,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       displayName,
       avatarUrl,
       tosAcceptedAt,
+      hasUsablePassword,
       consents,
       login,
       logout,

--- a/src/pages/accept-terms/accept-terms-page.test.tsx
+++ b/src/pages/accept-terms/accept-terms-page.test.tsx
@@ -48,6 +48,7 @@ function makeRouterAuth(overrides: {
       displayName: null,
       avatarUrl: null,
       tosAcceptedAt: overrides.tosAcceptedAt ?? null,
+      hasUsablePassword: true,
       consents: null,
       login: () => {},
       logout: async () => {},

--- a/src/pages/callback/google-callback-page.test.tsx
+++ b/src/pages/callback/google-callback-page.test.tsx
@@ -13,6 +13,7 @@ const unauthContext = {
     displayName: null,
     avatarUrl: null,
     tosAcceptedAt: null,
+    hasUsablePassword: false,
     consents: null,
     login: () => {},
     logout: async () => {},

--- a/src/pages/callback/steam-callback-page.test.tsx
+++ b/src/pages/callback/steam-callback-page.test.tsx
@@ -13,6 +13,7 @@ const unauthContext = {
     displayName: null,
     avatarUrl: null,
     tosAcceptedAt: null,
+    hasUsablePassword: false,
     consents: null,
     login: () => {},
     logout: async () => {},

--- a/src/pages/forgot-password/forgot-password-page.test.tsx
+++ b/src/pages/forgot-password/forgot-password-page.test.tsx
@@ -20,25 +20,24 @@ const unauthContext = {
   },
 }
 
-describe("LoginPage", () => {
-  it("renders the sign in form", async () => {
+describe("ForgotPasswordPage", () => {
+  it("starts with an empty email when no ?email= is supplied", async () => {
     await renderWithFileRoutes(<></>, {
-      initialLocation: "/login",
+      initialLocation: "/forgot-password",
       routerContext: unauthContext,
     })
-    expect(
-      screen.getByText("Sign in", { selector: "[data-slot='card-title']" })
-    ).toBeInTheDocument()
-    expect(screen.getByLabelText("Email")).toBeInTheDocument()
-    expect(screen.getByLabelText("Password")).toBeInTheDocument()
-    expect(screen.getByText("Sign in with Google")).toBeInTheDocument()
+
+    const input = await screen.findByLabelText<HTMLInputElement>("Email")
+    expect(input.value).toBe("")
   })
 
-  it("has a link to register", async () => {
+  it("prefills email from ?email= for the Set-a-password flow", async () => {
     await renderWithFileRoutes(<></>, {
-      initialLocation: "/login",
+      initialLocation: "/forgot-password?email=player%40example.com",
       routerContext: unauthContext,
     })
-    expect(screen.getByText("Sign up")).toBeInTheDocument()
+
+    const input = await screen.findByLabelText<HTMLInputElement>("Email")
+    expect(input.value).toBe("player@example.com")
   })
 })

--- a/src/pages/forgot-password/forgot-password-page.tsx
+++ b/src/pages/forgot-password/forgot-password-page.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { Link } from "@tanstack/react-router"
+import { Link, useSearch } from "@tanstack/react-router"
 import { LoaderCircle } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
@@ -17,7 +17,8 @@ import { api } from "@/api/api"
 import { getErrorMessage } from "@/lib/api-errors"
 
 export function ForgotPasswordPage() {
-  const [email, setEmail] = useState("")
+  const search = useSearch({ from: "/forgot-password" })
+  const [email, setEmail] = useState((search as { email?: string }).email ?? "")
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [submitted, setSubmitted] = useState(false)
 

--- a/src/pages/profile/profile-page.test.tsx
+++ b/src/pages/profile/profile-page.test.tsx
@@ -25,6 +25,7 @@ type AuthMeBody = {
   display_name: string | null
   avatar_url: string | null
   tos_accepted_at: string | null
+  has_usable_password?: boolean
 }
 
 const consentsHandler = http.get("*/user/consents", () =>
@@ -297,5 +298,169 @@ describe("ProfilePage connected accounts", () => {
     await waitFor(() =>
       expect(toast.success).toHaveBeenCalledWith("Linked your Google account.")
     )
+  })
+
+  it("disables Disconnect with a helper hint when removing it would strand the user", async () => {
+    const me = authMeHandler({
+      id: "u-1",
+      email: "player@example.com",
+      display_name: null,
+      avatar_url: null,
+      tos_accepted_at: "2026-01-01T00:00:00Z",
+      has_usable_password: false,
+    })
+    server.use(
+      me.handler,
+      consentsHandler,
+      http.get("*/auth/me/connections", () =>
+        HttpResponse.json([
+          {
+            provider: "google",
+            account_id: "g-1",
+            account_email: "player@gmail.com",
+          },
+        ])
+      )
+    )
+
+    await renderWithFileRoutes(<></>, { initialLocation: "/profile" })
+
+    const disconnect = await screen.findByRole("button", {
+      name: /disconnect/i,
+    })
+    expect(disconnect).toBeDisabled()
+    expect(screen.getByText(/no way to sign in/i)).toBeInTheDocument()
+  })
+
+  it("DELETEs the connection on click and refreshes the list", async () => {
+    const me = authMeHandler({
+      id: "u-1",
+      email: "player@example.com",
+      display_name: null,
+      avatar_url: null,
+      tos_accepted_at: "2026-01-01T00:00:00Z",
+      has_usable_password: true,
+    })
+
+    const linkedOnce = [
+      {
+        provider: "google",
+        account_id: "g-1",
+        account_email: "player@gmail.com",
+      },
+    ]
+    let connectionsState = linkedOnce
+    let deleteHit = false
+
+    server.use(
+      me.handler,
+      consentsHandler,
+      http.get("*/auth/me/connections", () =>
+        HttpResponse.json(connectionsState)
+      ),
+      http.delete("*/auth/me/connections/google", () => {
+        deleteHit = true
+        connectionsState = []
+        return new HttpResponse(null, { status: 204 })
+      })
+    )
+
+    await renderWithFileRoutes(<></>, { initialLocation: "/profile" })
+
+    const disconnect = await screen.findByRole("button", {
+      name: /disconnect/i,
+    })
+    expect(disconnect).not.toBeDisabled()
+
+    const user = userEvent.setup()
+    await user.click(disconnect)
+
+    await waitFor(() => expect(deleteHit).toBe(true))
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith("Disconnected Google.")
+    )
+  })
+
+  it("renders the remediation list when the server returns unlink_would_strand_user", async () => {
+    const me = authMeHandler({
+      id: "u-1",
+      email: "player@example.com",
+      display_name: null,
+      avatar_url: null,
+      tos_accepted_at: "2026-01-01T00:00:00Z",
+      has_usable_password: true,
+    })
+    server.use(
+      me.handler,
+      consentsHandler,
+      http.get("*/auth/me/connections", () =>
+        HttpResponse.json([
+          {
+            provider: "google",
+            account_id: "g-1",
+            account_email: "player@gmail.com",
+          },
+        ])
+      ),
+      http.delete("*/auth/me/connections/google", () =>
+        HttpResponse.json(
+          {
+            detail: {
+              code: "unlink_would_strand_user",
+              message:
+                "Disconnecting this account would leave you with no way to sign in.",
+              provider: "google",
+              remediation: [
+                "set a password via /auth/forgot-password first",
+                "link another provider that provides an email",
+              ],
+            },
+          },
+          { status: 409 }
+        )
+      )
+    )
+
+    await renderWithFileRoutes(<></>, { initialLocation: "/profile" })
+
+    const disconnect = await screen.findByRole("button", {
+      name: /disconnect/i,
+    })
+    const user = userEvent.setup()
+    await user.click(disconnect)
+
+    expect(await screen.findByTestId("stranding-issue")).toBeInTheDocument()
+    expect(screen.getByText(/set a password/i)).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /start now/i })).toBeInTheDocument()
+  })
+
+  it("renders the set-a-password CTA when the user has no usable password", async () => {
+    const me = authMeHandler({
+      id: "u-1",
+      email: "player@example.com",
+      display_name: null,
+      avatar_url: null,
+      tos_accepted_at: "2026-01-01T00:00:00Z",
+      has_usable_password: false,
+    })
+    server.use(
+      me.handler,
+      consentsHandler,
+      http.get("*/auth/me/connections", () =>
+        HttpResponse.json([
+          {
+            provider: "google",
+            account_id: "g-1",
+            account_email: "player@gmail.com",
+          },
+        ])
+      )
+    )
+
+    await renderWithFileRoutes(<></>, { initialLocation: "/profile" })
+
+    expect(
+      await screen.findByRole("link", { name: /set a password/i })
+    ).toBeInTheDocument()
   })
 })

--- a/src/pages/profile/profile-page.tsx
+++ b/src/pages/profile/profile-page.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from "react"
-import { useNavigate } from "@tanstack/react-router"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { Link, useNavigate } from "@tanstack/react-router"
 import { LoaderCircle } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
@@ -26,6 +26,17 @@ const PROVIDERS: { id: ProviderId; label: string }[] = [
   { id: "google", label: "Google" },
   { id: "steam", label: "Steam" },
 ]
+
+async function readErrorDetail(error: unknown): Promise<unknown> {
+  const response = (error as { response?: Response })?.response
+  if (!response) return null
+  try {
+    const body = await response.clone().json()
+    return body?.detail ?? null
+  } catch {
+    return null
+  }
+}
 
 interface ConsentToggleCopy {
   label: string
@@ -64,28 +75,33 @@ export function ProfilePage() {
   )
   const [connectingProvider, setConnectingProvider] =
     useState<ProviderId | null>(null)
+  const [disconnectingProvider, setDisconnectingProvider] =
+    useState<ProviderId | null>(null)
+  const [strandingIssue, setStrandingIssue] = useState<{
+    message: string
+    remediation: string[]
+  } | null>(null)
 
   useEffect(() => {
     setDisplayName(auth.displayName ?? "")
   }, [auth.displayName])
 
-  useEffect(() => {
-    let cancelled = false
-    api
-      .get("auth/me/connections")
-      .json<ProviderConnection[]>()
-      .then((list) => {
-        if (!cancelled) setConnections(list)
-      })
-      .catch(() => {
-        // Show an empty list rather than blocking the rest of the page; the
-        // user can refresh to retry. Avoids a noisy toast on transient errors.
-        if (!cancelled) setConnections([])
-      })
-    return () => {
-      cancelled = true
+  const refreshConnections = useCallback(async () => {
+    try {
+      const list = await api
+        .get("auth/me/connections")
+        .json<ProviderConnection[]>()
+      setConnections(list)
+    } catch {
+      // Show an empty list rather than blocking the rest of the page; the
+      // user can refresh to retry. Avoids a noisy toast on transient errors.
+      setConnections([])
     }
   }, [])
+
+  useEffect(() => {
+    void refreshConnections()
+  }, [refreshConnections])
 
   useEffect(() => {
     if (!search.linked) return
@@ -169,6 +185,59 @@ export function ProfilePage() {
       )
       toast.error(message)
       setConnectingProvider(null)
+    }
+  }
+
+  async function handleDisconnect(provider: ProviderId) {
+    setDisconnectingProvider(provider)
+    setStrandingIssue(null)
+    try {
+      await api.delete(`auth/me/connections/${provider}`)
+      await refreshConnections()
+      // /auth/me changes too (has_usable_password unaffected, but cookies may
+      // refresh on the same response). Re-check so the rest of the page is
+      // accurate.
+      await auth.checkAuth()
+      const label = PROVIDERS.find((p) => p.id === provider)?.label ?? provider
+      toast.success(`Disconnected ${label}.`)
+    } catch (error) {
+      const detail = await readErrorDetail(error)
+      if (
+        detail &&
+        typeof detail === "object" &&
+        (detail as { code?: unknown }).code === "unlink_would_strand_user"
+      ) {
+        const d = detail as {
+          message?: string
+          remediation?: unknown
+        }
+        const remediation = Array.isArray(d.remediation)
+          ? (d.remediation.filter((r) => typeof r === "string") as string[])
+          : []
+        setStrandingIssue({
+          message:
+            d.message ??
+            "Disconnecting this account would leave you with no way to sign in.",
+          remediation,
+        })
+        // Server saw a different reality than we did; refresh so the UI
+        // reflects the truth.
+        await refreshConnections()
+        await auth.checkAuth()
+      } else if (
+        detail &&
+        typeof detail === "object" &&
+        (detail as { code?: unknown }).code === "connection_not_found"
+      ) {
+        // Stale UI — the connection is already gone. Resync and tell the user.
+        await refreshConnections()
+        toast.info("That connection is already disconnected.")
+      } else {
+        const message = await getErrorMessage(error, "Failed to disconnect")
+        toast.error(message)
+      }
+    } finally {
+      setDisconnectingProvider(null)
     }
   }
 
@@ -323,51 +392,131 @@ export function ProfilePage() {
                 Loading…
               </p>
             ) : (
-              PROVIDERS.map(({ id, label }) => {
-                const linked = connections.find((c) => c.provider === id)
-                const isConnecting = connectingProvider === id
-                return (
-                  <div
-                    key={id}
-                    className="flex items-center justify-between gap-3"
-                  >
-                    <div className="grid gap-0.5">
-                      <span className="text-sm font-medium">{label}</span>
+              <>
+                {PROVIDERS.map(({ id, label }) => {
+                  const linked = connections.find((c) => c.provider === id)
+                  const isConnecting = connectingProvider === id
+                  const isDisconnecting = disconnectingProvider === id
+                  // Stranding guard: removing this connection is only safe if
+                  // either another connection remains, or the user has a
+                  // password they can fall back to. Mirrors the server-side
+                  // rule so the user doesn't have to click Disconnect to learn
+                  // it's blocked.
+                  const otherConnections = connections.filter(
+                    (c) => c.provider !== id
+                  )
+                  const hasPasswordFallback =
+                    auth.hasUsablePassword && !!auth.email
+                  const canUnlink =
+                    !!linked &&
+                    (otherConnections.length > 0 || hasPasswordFallback)
+                  return (
+                    <div
+                      key={id}
+                      className="flex items-start justify-between gap-3"
+                    >
+                      <div className="grid gap-0.5">
+                        <span className="text-sm font-medium">{label}</span>
+                        {linked ? (
+                          <span className="text-muted-foreground text-xs">
+                            Connected
+                            {(linked.account_email ?? linked.account_id) && (
+                              <>
+                                {" as "}
+                                <span className="font-mono">
+                                  {linked.account_email ?? linked.account_id}
+                                </span>
+                              </>
+                            )}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground text-xs">
+                            Not connected
+                          </span>
+                        )}
+                        {linked && !canUnlink && (
+                          <span className="text-muted-foreground text-xs">
+                            You'd have no way to sign in. Set a password first
+                            or link another provider.
+                          </span>
+                        )}
+                      </div>
                       {linked ? (
-                        <span className="text-muted-foreground text-xs">
-                          Connected
-                          {(linked.account_email ?? linked.account_id) && (
-                            <>
-                              {" as "}
-                              <span className="font-mono">
-                                {linked.account_email ?? linked.account_id}
-                              </span>
-                            </>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleDisconnect(id)}
+                          disabled={!canUnlink || isDisconnecting}
+                        >
+                          Disconnect
+                          {isDisconnecting && (
+                            <LoaderCircle className="animate-spin" />
                           )}
-                        </span>
+                        </Button>
                       ) : (
-                        <span className="text-muted-foreground text-xs">
-                          Not connected
-                        </span>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleConnect(id)}
+                          disabled={isConnecting}
+                        >
+                          Connect
+                          {isConnecting && (
+                            <LoaderCircle className="animate-spin" />
+                          )}
+                        </Button>
                       )}
                     </div>
-                    {!linked && (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() => handleConnect(id)}
-                        disabled={isConnecting}
-                      >
-                        Connect
-                        {isConnecting && (
-                          <LoaderCircle className="animate-spin" />
-                        )}
-                      </Button>
+                  )
+                })}
+                {strandingIssue && (
+                  <div
+                    className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs leading-relaxed"
+                    data-testid="stranding-issue"
+                  >
+                    <p className="mb-1 text-amber-200">
+                      {strandingIssue.message}
+                    </p>
+                    {strandingIssue.remediation.length > 0 && (
+                      <ul className="text-muted-foreground list-disc space-y-0.5 pl-4">
+                        {strandingIssue.remediation.map((hint, idx) => (
+                          <li key={idx}>
+                            {/set a password/i.test(hint) && auth.email ? (
+                              <>
+                                {hint}{" "}
+                                <Link
+                                  to="/forgot-password"
+                                  search={{ email: auth.email }}
+                                  className="text-primary underline"
+                                >
+                                  Start now.
+                                </Link>
+                              </>
+                            ) : (
+                              hint
+                            )}
+                          </li>
+                        ))}
+                      </ul>
                     )}
                   </div>
-                )
-              })
+                )}
+                {!auth.hasUsablePassword && auth.email && (
+                  <p className="text-muted-foreground text-xs">
+                    You don't have a password set.{" "}
+                    <Link
+                      to="/forgot-password"
+                      search={{ email: auth.email }}
+                      className="text-primary underline"
+                    >
+                      Set a password
+                    </Link>{" "}
+                    to also sign in with your email.
+                  </p>
+                )}
+              </>
             )}
           </div>
 

--- a/src/pages/verify-email/verify-email-page.test.tsx
+++ b/src/pages/verify-email/verify-email-page.test.tsx
@@ -13,6 +13,7 @@ const unauthContext = {
     displayName: null,
     avatarUrl: null,
     tosAcceptedAt: null,
+    hasUsablePassword: false,
     consents: null,
     login: () => {},
     logout: async () => {},

--- a/src/routes/__root.test.tsx
+++ b/src/routes/__root.test.tsx
@@ -20,6 +20,7 @@ function makeAuthContext(overrides: {
       displayName: "ZeroEmpires",
       avatarUrl: null,
       tosAcceptedAt: overrides.tosAcceptedAt ?? null,
+      hasUsablePassword: true,
       consents: null,
       login: () => {},
       logout: async () => {},

--- a/src/routes/forgot-password.tsx
+++ b/src/routes/forgot-password.tsx
@@ -1,9 +1,20 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
 import { ForgotPasswordPage } from "@/pages/forgot-password/forgot-password-page"
 
+type ForgotPasswordSearch = {
+  email?: string
+}
+
 export const Route = createFileRoute("/forgot-password")({
-  beforeLoad: ({ context }) => {
-    if (context.auth.isAuthenticated) {
+  validateSearch: (search: Record<string, unknown>): ForgotPasswordSearch =>
+    typeof search.email === "string" && search.email
+      ? { email: search.email }
+      : {},
+  beforeLoad: ({ context, search }) => {
+    // Authenticated users coming from the "Set a password" CTA need this page
+    // to mint a token — don't bounce them when they explicitly opted in with
+    // ?email=...; otherwise keep the existing "you're already signed in" guard.
+    if (context.auth.isAuthenticated && !search.email) {
       throw redirect({ to: "/profile" })
     }
   },

--- a/src/test/renderers.tsx
+++ b/src/test/renderers.tsx
@@ -25,6 +25,7 @@ interface RenderWithFileRoutesOptions extends Omit<RenderOptions, "wrapper"> {
       displayName: string | null
       avatarUrl: string | null
       tosAcceptedAt: string | null
+      hasUsablePassword: boolean
       consents: ConsentsResponse | null
       login: (email: string) => void
       logout: () => Promise<void>
@@ -42,6 +43,7 @@ const defaultAuth = {
   displayName: null,
   avatarUrl: null,
   tosAcceptedAt: null,
+  hasUsablePassword: true,
   consents: null,
   login: () => {},
   logout: async () => {},


### PR DESCRIPTION
PR-B of two for #39. Builds on #41 (Connect flow) to close out the frontend portion of the issue.

## Summary

- Plumb `has_usable_password` from `/auth/me` through the auth context (defaults to `false` on missing/stale responses).
- Disconnect button per linked provider on `/profile`. Disabled with an inline hint ("You'd have no way to sign in. Set a password first or link another provider.") when removing it would strand the user — mirrors the server-side rule client-side so users don't have to click to learn it's blocked:
  ```ts
  canUnlink = otherConnections.length > 0
            || (hasUsablePassword && email)
  ```
- `DELETE /auth/me/connections/{provider}` on click:
  - **204** → refresh `/auth/me/connections` + `/auth/me`, toast _"Disconnected <Provider>."_
  - **409 `unlink_would_strand_user`** → render the message + remediation list inline (amber alert). Remediation strings matching `/set a password/` get a "Start now" Link to `/forgot-password?email=<email>`. Re-syncs connections + auth in case the server saw a different reality.
  - **404 `connection_not_found`** → refresh connections, toast _"That connection is already disconnected."_
- "Set a password" CTA in the connections section when `has_usable_password=false`, linking to `/forgot-password?email=<email>`.
- `forgot-password` route now accepts `?email=` via `validateSearch` and prefills the input. The "authenticated user → /profile" guard relaxes when `?email=` is present so the CTA works without forcing a logout.

## Closes

Together with #41, the frontend portion of #39 (Steam associate flow + connect/disconnect settings UI) is done.

## Test plan

### Unit (vitest, 6 new tests, 45 total — all passing)
- `forgot-password-page.test.tsx` — empty default, `?email=` prefill.
- `profile-page.test.tsx` — Disconnect disabled with helper text when stranding, DELETE on click + list refresh + success toast, 409 → rendered remediation list with "Start now" Link, "Set a password" CTA visible when `has_usable_password=false`.
- All other auth-context test contexts updated for the new `hasUsablePassword` field (default `false` for unauth, `true` for the existing auth fixtures).

### What's not in this PR
- E2E re-run. PR-A (#41) already verified the connections section round-trip live against the local API + Postgres; the net-new logic here (Disconnect button rendering, stranding guard, 409 remediation rendering, CTA, forgot-password prefill) is mechanical UI on top of the same wiring and is fully covered by the new unit tests. Happy to run a fresh Playwright session if you'd prefer it before merging — just ask.

## Reviewer checklist

- [ ] `pnpm test:run`
- [ ] Locally: log in as a user with both Google and Steam linked → both rows show Disconnect, both enabled.
- [ ] Log in as a user with `has_usable_password=false` and only Google linked → Disconnect shows but is disabled with the "no way to sign in" hint, and the "Set a password" CTA appears below.
- [ ] Click the CTA → lands on `/forgot-password` with the email prefilled.