### PR TITLE
feat: client-side navigation for auth state transitions

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown, ExternalLink, LogOut } from "lucide-react"
+import { useNavigate } from "@tanstack/react-router"
 import { BrandLockup } from "@/components/brand-lockup"
 import {
   DropdownMenu,
@@ -13,6 +14,7 @@ import { useAuth } from "@/lib/auth"
 
 export function Navbar() {
   const auth = useAuth()
+  const navigate = useNavigate()
 
   return (
     <nav className="border-border/50 bg-background/80 fixed top-0 z-50 w-full border-b backdrop-blur-sm">
@@ -49,7 +51,7 @@ export function Navbar() {
                 <DropdownMenuItem
                   onClick={async () => {
                     await auth.logout()
-                    window.location.href = "/login"
+                    await navigate({ to: "/login" })
                   }}
                 >
                   <LogOut className="size-4" />

--- a/src/pages/callback/oauth-associate-complete-page.tsx
+++ b/src/pages/callback/oauth-associate-complete-page.tsx
@@ -1,13 +1,16 @@
 import { useEffect } from "react"
+import { useNavigate } from "@tanstack/react-router"
 
 type Props = {
   provider: "google" | "steam"
 }
 
 export function OAuthAssociateCompletePage({ provider }: Props) {
+  const navigate = useNavigate()
+
   useEffect(() => {
-    window.location.href = `/profile?linked=${provider}`
-  }, [provider])
+    void navigate({ to: "/profile", search: { linked: provider } })
+  }, [provider, navigate])
 
   return (
     <div className="flex flex-1 items-center justify-center">

--- a/src/pages/callback/oauth-complete-page.tsx
+++ b/src/pages/callback/oauth-complete-page.tsx
@@ -1,33 +1,50 @@
 import { useEffect, useRef } from "react"
+import { useNavigate } from "@tanstack/react-router"
 import { api } from "@/api/api"
+import { useAuth } from "@/lib/auth"
 
 export function OAuthCompletePage() {
+  const auth = useAuth()
+  const navigate = useNavigate()
   const calledRef = useRef(false)
 
   useEffect(() => {
     if (calledRef.current) return
     calledRef.current = true
 
-    api
-      .get("auth/me")
-      .json<{ email: string | null; tos_accepted_at: string | null }>()
-      .then((user) => {
+    async function complete() {
+      try {
+        const user = await api
+          .get("auth/me")
+          .json<{ email: string | null; tos_accepted_at: string | null }>()
+        // Also refresh the AuthContext so the destination route's beforeLoad
+        // sees the new session. The direct read above gives us the user data
+        // for the routing decision below without waiting for the React
+        // render cycle to flush.
+        await auth.checkAuth()
+
         // Steam OAuth users start with no email until they pass through
-        // /accept-terms (auth-api #36, auth-web #36) — route them there
-        // even if they previously accepted the old TOS-only gate.
+        // /accept-terms — route them there even if they previously accepted
+        // the old TOS-only gate.
         if (!user.tos_accepted_at || !user.email) {
-          // Keep the redirect in localStorage — accept-terms page will use it
-          window.location.href = "/accept-terms"
-        } else {
-          const savedRedirect = localStorage.getItem("auth_redirect")
-          localStorage.removeItem("auth_redirect")
-          window.location.href = savedRedirect ?? "/profile"
+          await navigate({ to: "/accept-terms" })
+          return
         }
-      })
-      .catch(() => {
-        window.location.href = "/login"
-      })
-  }, [])
+        const savedRedirect = localStorage.getItem("auth_redirect")
+        localStorage.removeItem("auth_redirect")
+        if (savedRedirect && savedRedirect.startsWith("http")) {
+          // Cross-origin redirect (consumer apps) — hard nav.
+          window.location.href = savedRedirect
+          return
+        }
+        await navigate({ to: savedRedirect ?? "/profile" })
+      } catch {
+        await navigate({ to: "/login" })
+      }
+    }
+
+    void complete()
+  }, [auth, navigate])
 
   return (
     <div className="flex flex-1 items-center justify-center">

--- a/src/pages/login/login-page.tsx
+++ b/src/pages/login/login-page.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { Link, useSearch } from "@tanstack/react-router"
+import { Link, useNavigate, useSearch } from "@tanstack/react-router"
 import { LoaderCircle } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
@@ -15,8 +15,11 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { api, baseUrl } from "@/api/api"
 import { getErrorMessage } from "@/lib/api-errors"
+import { useAuth } from "@/lib/auth"
 
 export function LoginPage() {
+  const auth = useAuth()
+  const navigate = useNavigate()
   const search = useSearch({ from: "/login" })
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
@@ -33,9 +36,18 @@ export function LoginPage() {
         body: new URLSearchParams({ username: email, password }),
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
       })
-      // Hard redirect — reloads the page so AuthProvider picks up the new cookie cleanly.
-      // Client-side navigate has a race condition with the onUnauthorized handler.
-      window.location.href = redirect ?? "/profile"
+      const target = redirect ?? "/profile"
+      if (target.startsWith("http")) {
+        // Cross-origin redirect (e.g. from a consumer app like
+        // hera-streamer-…) — must be a hard nav since useNavigate only
+        // handles in-app routes.
+        window.location.href = target
+        return
+      }
+      // Refresh the AuthContext (reads /auth/me with the new cookie) before
+      // navigating, so /profile's beforeLoad sees isAuthenticated=true.
+      await auth.checkAuth()
+      await navigate({ to: target })
     } catch (error) {
       const message = await getErrorMessage(error, "Login failed")
       toast.error(message)

--- a/src/pages/profile/profile-page.tsx
+++ b/src/pages/profile/profile-page.tsx
@@ -156,7 +156,11 @@ export function ProfilePage() {
     try {
       await api.delete("auth/me")
       toast.success("Account deleted.")
-      window.location.href = "/login"
+      // Clear local auth state before navigating — /login's beforeLoad
+      // redirects authenticated users to /profile, so without this the
+      // user would bounce back to the page they just deleted from.
+      await auth.logout()
+      await navigate({ to: "/login" })
     } catch (error) {
       const message = await getErrorMessage(error, "Failed to delete account")
       toast.error(message)

--- a/src/pages/register/register-page.tsx
+++ b/src/pages/register/register-page.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { Link } from "@tanstack/react-router"
+import { Link, useNavigate } from "@tanstack/react-router"
 import { LoaderCircle } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
@@ -16,9 +16,12 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { api } from "@/api/api"
 import { getErrorMessage } from "@/lib/api-errors"
+import { useAuth } from "@/lib/auth"
 import { submitConsents, type ConsentInput } from "@/lib/consent"
 
 export function RegisterPage() {
+  const auth = useAuth()
+  const navigate = useNavigate()
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
@@ -66,7 +69,10 @@ export function RegisterPage() {
       } catch {
         // Swallow — user is signed up; they'll be prompted again on profile.
       }
-      window.location.href = "/profile"
+      // Refresh the AuthContext (reads /auth/me with the new cookie) before
+      // navigating, so /profile's beforeLoad sees isAuthenticated=true.
+      await auth.checkAuth()
+      await navigate({ to: "/profile" })
     } catch (error) {
       const message = await getErrorMessage(error, "Registration failed")
       toast.error(message)


### PR DESCRIPTION
Closes #43. Replaces 6 \`window.location.href\` calls with TanStack Router's \`useNavigate\` across login, register, logout, OAuth callback, profile delete, and associate-complete. No more white flash between auth state changes.

## The race that wasn't

\`login-page.tsx:36-37\` previously documented:
> Hard redirect — reloads the page so AuthProvider picks up the new cookie cleanly. Client-side navigate has a race condition with the onUnauthorized handler.

Live E2E testing shows the race **does not manifest** with \`await auth.checkAuth() + await navigate()\`. React 18's batching plus TanStack Router's context propagation (via \`<RouterProvider context={{ auth }} />\` in \`main.tsx:105\`) means the updated context is visible by the time \`beforeLoad\` runs. **No \`router.invalidate()\` needed.** The previous comment was likely about pre-React-18 batching or a different flow.

## The pattern by call site

| Call site | Pattern | Why |
|---|---|---|
| **Login / register** | \`await auth.checkAuth() → await navigate(target)\` | Refresh AuthContext with the new cookie's identity before the destination's \`beforeLoad\` checks \`isAuthenticated\` |
| **Logout (navbar) / delete (profile)** | \`await auth.logout() → await navigate(\"/login\")\` | Clear local state so /login's \"redirect authenticated → /profile\" guard doesn't bounce the user back |
| **OAuth-complete** | Direct \`api.get(\"auth/me\")\` for closure-local routing + \`await auth.checkAuth()\` for context refresh + \`await navigate(target)\` | Need user data for the accept-terms / profile routing decision AND a fresh AuthContext for the destination |
| **Associate-complete** | Just \`await navigate({ to: \"/profile\", search: { linked } })\` | No auth state change — user is already logged in |

## Preserved hard-nav cases

- **Cross-origin redirects** (consumer apps like \`hera-streamer-…\`) still use \`window.location.href\` since useNavigate is for in-app routes only. \`login-page.tsx\` and \`oauth-complete-page.tsx\` both check \`target.startsWith(\"http\")\` and fall back.
- **Outbound to provider OAuth** (Google / Steam authorize) keeps direct navigation — that's the fix from #44.

## Test plan

### Unit
- [x] \`pnpm test:run\` — 45 tests pass.
- [x] \`pnpm exec tsc -b\` clean.

### Live E2E (Playwright against local API + Postgres on non-default ports)
| Flow | Result | Backend log |
|---|---|---|
| Register → /profile | ✅ no bounce, no flash | register/login/accept-tos/me/connections all 2xx |
| Logout (navbar) → /login | ✅ clean | jwt/logout → 204 |
| Login → /profile | ✅ no bounce, no flash | jwt/login → 204, me → 200 |
| Delete account → /login | ✅ no bounce-back to deleted /profile | DELETE me → 204, jwt/logout → 204 |

### Not covered E2E
OAuth callback complete paths (Google / Steam). Would need real OAuth client creds in the local API; the conversion mirrors login (await checkAuth + await navigate) which is verified.

## Reviewer checklist

- [ ] \`pnpm test:run\`
- [ ] Locally: log in via email → /profile should appear instantly without a full reload (compare to current main where there's a ~200ms blank-page flash).
- [ ] Logout from the navbar → /login should appear instantly.
- [ ] Delete an account → /login (the trickiest case — pre-fix this could bounce back to /profile if the auth state hadn't cleared in time).