### PR TITLE
fix(register): preserve ?redirect= through cross-origin sign-in flows

### DIFF
--- a/src/pages/login/login-page.test.tsx
+++ b/src/pages/login/login-page.test.tsx
@@ -41,4 +41,19 @@ describe("LoginPage", () => {
     })
     expect(screen.getByText("Sign up")).toBeInTheDocument()
   })
+
+  it("preserves ?redirect= on the Sign up link", async () => {
+    await renderWithFileRoutes(<></>, {
+      initialLocation:
+        "/login?redirect=https%3A%2F%2Fhera-streamer-invitational-2026.criticalbit.gg%2F",
+      routerContext: unauthContext,
+    })
+    const link = await screen.findByRole("link", { name: "Sign up" })
+    // TanStack Router serializes search params alphabetically and re-encodes —
+    // the important thing is that the redirect target survives the hop, not
+    // the exact encoding.
+    expect(link.getAttribute("href")).toMatch(
+      /^\/register\?redirect=.*hera-streamer-invitational-2026\.criticalbit\.gg/
+    )
+  })
 })

--- a/src/pages/login/login-page.tsx
+++ b/src/pages/login/login-page.tsx
@@ -177,7 +177,11 @@ export function LoginPage() {
         <CardFooter className="justify-center">
           <p className="text-muted-foreground text-sm">
             Don't have an account?{" "}
-            <Link to="/register" className="text-primary underline">
+            <Link
+              to="/register"
+              search={redirect ? { redirect } : {}}
+              className="text-primary underline"
+            >
               Sign up
             </Link>
           </p>

--- a/src/pages/register/register-page.tsx
+++ b/src/pages/register/register-page.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { Link, useNavigate } from "@tanstack/react-router"
+import { Link, useNavigate, useSearch } from "@tanstack/react-router"
 import { LoaderCircle } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
@@ -22,6 +22,8 @@ import { submitConsents, type ConsentInput } from "@/lib/consent"
 export function RegisterPage() {
   const auth = useAuth()
   const navigate = useNavigate()
+  const search = useSearch({ from: "/register" })
+  const redirect = (search as { redirect?: string }).redirect
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
@@ -70,9 +72,17 @@ export function RegisterPage() {
         // Swallow — user is signed up; they'll be prompted again on profile.
       }
       // Refresh the AuthContext (reads /auth/me with the new cookie) before
-      // navigating, so /profile's beforeLoad sees isAuthenticated=true.
+      // navigating, so the destination's beforeLoad sees isAuthenticated=true.
       await auth.checkAuth()
-      await navigate({ to: "/profile" })
+      const target = redirect ?? "/profile"
+      if (target.startsWith("http")) {
+        // Cross-origin redirect (e.g. from a consumer app like
+        // hera-streamer-…) — must be a hard nav since useNavigate only
+        // handles in-app routes.
+        window.location.href = target
+        return
+      }
+      await navigate({ to: target })
     } catch (error) {
       const message = await getErrorMessage(error, "Registration failed")
       toast.error(message)

--- a/src/routes/register.tsx
+++ b/src/routes/register.tsx
@@ -1,7 +1,14 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
 import { RegisterPage } from "@/pages/register/register-page"
 
+type RegisterSearch = {
+  redirect?: string
+}
+
 export const Route = createFileRoute("/register")({
+  validateSearch: (search: Record<string, unknown>): RegisterSearch => ({
+    redirect: (search.redirect as string) || undefined,
+  }),
   beforeLoad: ({ context }) => {
     if (context.auth.isAuthenticated) {
       throw redirect({ to: "/profile" })


### PR DESCRIPTION
Closes #47. Three small changes that mirror how \`/login\` already handles \`?redirect=\`.

## Symptom

A new user clicking through from a consumer app (e.g. \`hera-streamer-invitational-2026.criticalbit.gg\`) lands at \`auth.criticalbit.gg/login?redirect=https://hera-…/\`, sees _\"Don't have an account? Sign up\"_, clicks, registers, and ends up at \`/profile\` instead of being bounced back to the consumer app.

## Fix

1. **\`login-page.tsx\` Sign-up Link** — pass \`search={redirect ? { redirect } : {}}\` so the query param survives the click.
2. **\`routes/register.tsx\`** — add \`validateSearch\` for the redirect param, matching \`/login\`'s shape.
3. **\`register-page.tsx\`** — after the auto-login + \`auth.checkAuth()\`, route to the redirect target with the same cross-origin (\`window.location.href\`) vs in-app (\`navigate\`) split that \`login-page.tsx\` uses.

## Test plan

- [x] \`pnpm test:run\` — 46 tests pass (1 new: \"preserves ?redirect= on the Sign up link\").
- [ ] Locally: visit \`/login?redirect=https://example.com/\`, click \"Sign up\" → \`/register?redirect=https://example.com/\`.
- [ ] Register → hard-navigates to \`https://example.com/\`.
- [ ] Plain \`/register\` (no redirect) → \`/profile\` (unchanged).

## Adjacent

Issue #46 (display-name suggestions) covers the new-user-from-consumer-app flow at the UX level. With #47 + #46 both shipped, the flow feels right end-to-end: redirect preserved, optional name field at register, nudge on /profile if skipped.