### PR TITLE
fix: satisfy react-hooks/set-state-in-effect and immutability

### DIFF
--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -127,6 +127,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [clearState])
 
   useEffect(() => {
+    // checkAuth is async: its setState calls run after an await, not
+    // synchronously within the effect body, so cascading renders don't apply.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     checkAuth()
   }, [checkAuth])
 

--- a/src/pages/profile/profile-page.tsx
+++ b/src/pages/profile/profile-page.tsx
@@ -109,6 +109,10 @@ export function ProfilePage() {
   }
 
   useEffect(() => {
+    // Seeds the editable field from context and re-seeds when the source
+    // changes. A controlled input has to hold its own draft, so this sync is
+    // the point rather than an accident; it settles in one extra render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setDisplayName(auth.displayName ?? "")
   }, [auth.displayName])
 
@@ -126,6 +130,9 @@ export function ProfilePage() {
   }, [])
 
   useEffect(() => {
+    // refreshConnections awaits the request before any setState, so its
+    // updates don't run synchronously within the effect body.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void refreshConnections()
   }, [refreshConnections])
 
@@ -138,6 +145,10 @@ export function ProfilePage() {
 
   useEffect(() => {
     if (!search.associate_error || !search.associate_provider) return
+    // Surfaces an error carried in the URL, then clears the params via
+    // navigate() on the next line -- so the guard above stops matching and
+    // this runs once rather than cascading.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setAssociateError({
       provider: search.associate_provider,
       message: associateErrorMessage(
@@ -214,6 +225,9 @@ export function ProfilePage() {
     // via fetch — CSP connect-src blocks the cross-origin call to
     // accounts.google.com / steamcommunity.com. Direct navigation
     // sidesteps connect-src entirely.
+    // Assigning location is the navigation itself, not a mutation of app
+    // state -- see the comment above for why a fetch can't be used here.
+    // eslint-disable-next-line react-hooks/immutability
     window.location.href = `${baseUrl}/auth/${provider}/associate/authorize`
   }
 


### PR DESCRIPTION
eslint-plugin-react-hooks 7.1.x — arriving via #61 — errors on **five** pre-existing sites. Each is deliberate, so each gets a disable with its own justification rather than a restructure.

| Site | Why it's fine |
|---|---|
| `auth.tsx` — `checkAuth()` | Async; setState runs after an `await`, not synchronously in the effect body |
| `profile-page.tsx` — `setDisplayName` | Seeds an editable field from context and re-seeds when the source changes. A controlled input must hold its own draft, so the sync is the point; settles in one extra render |
| `profile-page.tsx` — `refreshConnections` | Awaits the request before any setState |
| `profile-page.tsx` — `setAssociateError` | Surfaces an error carried in the URL, then clears the params via `navigate()` on the next line — so the guard stops matching and it runs once |
| `profile-page.tsx` — `window.location.href` (`react-hooks/immutability`) | Assigning location **is** the navigation, not a state mutation. The existing comment explains why a fetch can't be used: CSP `connect-src` blocks the cross-origin call |

Landing separately so a 35-package dependency update isn't blocked on pre-existing patterns. Until the bump lands the directives are unused — warnings, not errors.

Verified: zero error-severity findings under 7.1.1; lint, format, test and build pass on the current 7.0.1 pin.